### PR TITLE
Ac 1986 attachment upload performance

### DIFF
--- a/packages/apptive_grid_core/CHANGELOG.md
+++ b/packages/apptive_grid_core/CHANGELOG.md
@@ -1,3 +1,12 @@
+## 0.12.0
+* Update Attachment Processing
+* Add option to add an attachment with a path to a file instead of only the raw bytes
+### Breaking Changes
+* Resizing of images was changed to the following
+  * Requires an id for the operation
+  * Takes in a list of sizes it should resize to instead of doing each resize separately
+  * Returns a List of paths to the Files where the resized Images are stored
+
 ## 0.11.3
 * Add `submitFormWithProgress` to client to submit a Form and receive Progress Event Updates
 

--- a/packages/apptive_grid_core/lib/model/attachment/attachment_action.dart
+++ b/packages/apptive_grid_core/lib/model/attachment/attachment_action.dart
@@ -39,6 +39,7 @@ abstract class AttachmentAction {
           byteData: json['byteData'] != null
               ? Uint8List.fromList(json['byteData'].cast<int>())
               : null,
+          path: json['path'],
           attachment: attachment,
         );
       case AttachmentActionType.delete:
@@ -58,28 +59,34 @@ abstract class AttachmentAction {
 /// Implementation of an [AttachmentAction] for [AttachmentActionType.add]
 class AddAttachmentAction extends AttachmentAction {
   /// Creates an Add Action to upload [byteData] for [attachment]
-  AddAttachmentAction({required this.byteData, required attachment})
-      : super(attachment, AttachmentActionType.add);
+  AddAttachmentAction({this.byteData, this.path, required attachment})
+      : assert(byteData != null || path != null),
+        super(attachment, AttachmentActionType.add);
 
   /// Data for new Attachment
   final Uint8List? byteData;
+
+  /// The Path to a File for this Attachment
+  final String? path;
 
   @override
   Map<String, dynamic> toJson() => {
         'type': type.toString(),
         'attachment': attachment.toJson(),
         'byteData': byteData?.toList(growable: false),
+        'path': path,
       };
 
   @override
   String toString() {
-    return 'AddAttachmentAction(byteData(byteSize): ${byteData?.lengthInBytes}, attachment: $attachment)';
+    return 'AddAttachmentAction(path: $path, byteData(byteSize): ${byteData?.lengthInBytes}, attachment: $attachment)';
   }
 
   @override
   bool operator ==(Object other) {
     return other is AddAttachmentAction &&
         other.attachment == attachment &&
+        other.path == path &&
         f.listEquals(other.byteData?.toList(), byteData?.toList());
   }
 

--- a/packages/apptive_grid_core/lib/network/authentication/apptive_grid_authenticator.dart
+++ b/packages/apptive_grid_core/lib/network/authentication/apptive_grid_authenticator.dart
@@ -262,7 +262,7 @@ class ApptiveGridAuthenticator {
               ? LaunchMode.externalApplication
               : LaunchMode.inAppWebView,
         );
-      } on PlatformException {
+      } on PlatformException catch (_) {
         // Could not launch Url
       }
     }

--- a/packages/apptive_grid_core/pubspec.yaml
+++ b/packages/apptive_grid_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_core
 description: Core Library for ApptiveGrid used to provide general ApptiveGrid functionality to other Packages or Apps
-version: 0.11.3
+version: 0.12.0
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_core
 
@@ -9,6 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
+  collection: ^1.16.0
   image: ^3.2.0
   intl: ^0.17.0
   http: ^0.13.4
@@ -16,6 +17,7 @@ dependencies:
   provider: ^6.0.3
   openid_client: ^0.4.6
   uni_links: ^0.5.1
+  universal_file: ^1.0.0
   universal_platform: ^1.0.0+1
   url_launcher: ^6.1.2
   uuid: ^3.0.6

--- a/packages/apptive_grid_core/test/api_client_test.dart
+++ b/packages/apptive_grid_core/test/api_client_test.dart
@@ -1062,7 +1062,9 @@ void main() {
               );
               final action =
                   ApptiveLink(uri: Uri.parse('actionUri'), method: 'POST');
-              final bytes = Uint8List(10);
+              final bytes = base64Decode(
+                'iVBORw0KGgoAAAANSUhEUgAAAAIAAAAECAYAAACk7+45AAAAEklEQVR42mP8z/C/ngEIGHEzAMiQCfmnp5u6AAAAAElFTkSuQmCC',
+              );
               final attachmentAction =
                   AddAttachmentAction(byteData: bytes, attachment: attachment);
               const field = GridField(

--- a/packages/apptive_grid_form/CHANGELOG.md
+++ b/packages/apptive_grid_form/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.12.3
+* Attachments are now using their path when being added
+
 ## 0.12.2
 * Use new `submitFormWithProgress` and display the progress when submitting
 

--- a/packages/apptive_grid_form/lib/widgets/form_widget/attachment/add_attachment_button.dart
+++ b/packages/apptive_grid_form/lib/widgets/form_widget/attachment/add_attachment_button.dart
@@ -122,10 +122,11 @@ class _AddAttachmentButtonState extends State<AddAttachmentButton> {
       final client = ApptiveGrid.getClient(context, listen: false);
       final attachmentManager =
           Provider.of<AttachmentManager>(context, listen: false);
-      for (final file in result.files) {
+      for (final file
+          in result.files.where((element) => element.path != null)) {
         final attachment =
             await client.attachmentProcessor.createAttachment(file.name);
-        attachmentManager.addAttachment(attachment, file.bytes);
+        attachmentManager.addAttachment(attachment, file.path);
         newAttachments.add(attachment);
       }
       return newAttachments;
@@ -146,8 +147,7 @@ class _AddAttachmentButtonState extends State<AddAttachmentButton> {
         final attachment =
             await client.attachmentProcessor.createAttachment(file.name);
 
-        final bytes = await file.readAsBytes();
-        attachmentManager.addAttachment(attachment, bytes);
+        attachmentManager.addAttachment(attachment, file.path);
         newAttachments.add(attachment);
       }
       return newAttachments;
@@ -165,8 +165,8 @@ class _AddAttachmentButtonState extends State<AddAttachmentButton> {
           Provider.of<AttachmentManager>(context, listen: false);
       final newAttachment =
           await client.attachmentProcessor.createAttachment(file.name);
-      final bytes = await file.readAsBytes();
-      attachmentManager.addAttachment(newAttachment, bytes);
+
+      attachmentManager.addAttachment(newAttachment, file.path);
       return [newAttachment];
     } else {
       return null;

--- a/packages/apptive_grid_form/lib/widgets/form_widget/attachment_manager.dart
+++ b/packages/apptive_grid_form/lib/widgets/form_widget/attachment_manager.dart
@@ -1,5 +1,3 @@
-import 'dart:typed_data';
-
 import 'package:apptive_grid_form/apptive_grid_form.dart';
 
 /// Manages Attachment Actions for a [ApptiveGridFormData] Widget
@@ -11,9 +9,9 @@ class AttachmentManager {
   final FormData? formData;
 
   /// Adds an Attachment
-  void addAttachment(Attachment attachment, Uint8List? data) {
+  void addAttachment(Attachment attachment, String? path) {
     formData?.attachmentActions[attachment] =
-        AddAttachmentAction(byteData: data, attachment: attachment);
+        AddAttachmentAction(path: path, attachment: attachment);
   }
 
   /// Removes an Attachment. Used for deleting Attachments

--- a/packages/apptive_grid_form/pubspec.yaml
+++ b/packages/apptive_grid_form/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_form
 description: A Flutter Package to display ApptiveGrid Forms inside a Flutter App.
-version: 0.12.2
+version: 0.12.3
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_form
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  apptive_grid_core: ^0.11.3
+  apptive_grid_core: ^0.12.0
   file_picker: ^4.6.0
   flutter:
     sdk: flutter

--- a/packages/apptive_grid_form/test/apptive_grid_form_test.dart
+++ b/packages/apptive_grid_form/test/apptive_grid_form_test.dart
@@ -1196,8 +1196,7 @@ void main() {
         title: 'Form Title',
         components: [],
         attachmentActions: {
-          attachment:
-              AddAttachmentAction(byteData: null, attachment: attachment)
+          attachment: AddAttachmentAction(path: '', attachment: attachment)
         },
         links: {ApptiveLinkType.submit: action},
         fields: [],

--- a/packages/apptive_grid_form/test/attachment_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/attachment_form_widget_test.dart
@@ -32,6 +32,7 @@ void main() {
       testWidgets('Add Attachment from file picker', (tester) async {
         const filename = 'Filename.png';
         final bytes = Uint8List(10);
+        const path = 'path';
         final filePicker = MockFilePicker();
         final attachmentUri = Uri.parse('attachmenturl.com');
         when(
@@ -47,6 +48,7 @@ void main() {
               name: filename,
               size: bytes.lengthInBytes,
               bytes: bytes,
+              path: path,
             ),
           ]),
         );
@@ -125,6 +127,7 @@ void main() {
         const filename1 = 'Filename1.png';
         const filename2 = 'Filename2.pdf';
         final bytes = Uint8List(10);
+        const path = 'path';
         final filePicker = MockFilePicker();
         final attachmentUri1 = Uri.parse('$filename1.com');
         final attachmentUri2 = Uri.parse('$filename2.com');
@@ -141,11 +144,13 @@ void main() {
               name: filename1,
               size: bytes.lengthInBytes,
               bytes: bytes,
+              path: path,
             ),
             PlatformFile(
               name: filename2,
               size: bytes.lengthInBytes,
               bytes: bytes,
+              path: path,
             ),
           ]),
         );
@@ -328,6 +333,7 @@ void main() {
         when(() => mockFile.name).thenReturn(filename);
         when(() => mockFile.readAsBytes())
             .thenAnswer((invocation) async => bytes);
+        when(() => mockFile.path).thenReturn('path');
 
         when(
           () => imagePicker.getMultiImage(
@@ -427,10 +433,12 @@ void main() {
         when(() => mockFile1.name).thenReturn(filename1);
         when(() => mockFile1.readAsBytes())
             .thenAnswer((invocation) async => bytes);
+        when(() => mockFile1.path).thenReturn('path1');
 
         when(() => mockFile2.name).thenReturn(filename2);
         when(() => mockFile2.readAsBytes())
             .thenAnswer((invocation) async => bytes);
+        when(() => mockFile2.path).thenReturn('path2');
 
         when(
           () => imagePicker.getMultiImage(
@@ -549,6 +557,7 @@ void main() {
         when(() => mockFile.name).thenReturn(filename);
         when(() => mockFile.readAsBytes())
             .thenAnswer((invocation) async => bytes);
+        when(() => mockFile.path).thenReturn('path');
 
         when(
           () => imagePicker.getImage(
@@ -690,6 +699,7 @@ void main() {
     testWidgets('Added Attachment get removed', (tester) async {
       const filename = 'Filename.png';
       final bytes = Uint8List(10);
+      const path = 'path';
       final filePicker = MockFilePicker();
       final attachmentUri = Uri.parse('attachmenturl.com');
       when(
@@ -705,6 +715,7 @@ void main() {
             name: filename,
             size: bytes.lengthInBytes,
             bytes: bytes,
+            path: path,
           ),
         ]),
       );
@@ -921,6 +932,7 @@ void main() {
         'sends action', (tester) async {
       const filename = 'Filename.png';
       final bytes = Uint8List(10);
+      const path = 'path';
       final filePicker = MockFilePicker();
       final attachmentUri = Uri.parse('attachmenturl.com');
       when(
@@ -936,6 +948,7 @@ void main() {
             name: filename,
             size: bytes.lengthInBytes,
             bytes: bytes,
+            path: path,
           ),
         ]),
       );

--- a/packages/apptive_grid_grid_builder/CHANGELOG.md
+++ b/packages/apptive_grid_grid_builder/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.11.0
+* Update apptive_grid_core to [0.12.0](https://pub.dev/packages/apptive_grid_core/changelog#0120)
+
 ## 0.10.0
 * Renamed `UserReference` to `CreatedBy`. The old `UserReference` is still available but deprecated
 

--- a/packages/apptive_grid_grid_builder/pubspec.yaml
+++ b/packages/apptive_grid_grid_builder/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_grid_builder
 description: A Flutter Package to build Widgets based on Data from an ApptiveGrid Grid.
-version: 0.10.0
+version: 0.11.0
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_grid_builder
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  apptive_grid_core: ^0.11.0
+  apptive_grid_core: ^0.12.0
   flutter:
     sdk: flutter
 

--- a/packages/apptive_grid_user_management/CHANGELOG.md
+++ b/packages/apptive_grid_user_management/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.0
+* Promote to 0.1.0 release
+* Update apptive_grid_core to [0.12.0](https://pub.dev/packages/apptive_grid_core/changelog#0120)
+
 ## 0.0.6
 * Adjust handling of different scenarios
   * Login with valid credentials but user not part of the group: Ask to join group

--- a/packages/apptive_grid_user_management/pubspec.yaml
+++ b/packages/apptive_grid_user_management/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_user_management
 description: Package to add UserManagement through ApptiveGrid to a Flutter App. This provides Login/Register Widgets and options to confirm accoutns
-version: 0.0.6
+version: 0.1.0
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_user_management
 
@@ -9,7 +9,7 @@ environment:
   flutter: ">=1.17.0"
 
 dependencies:
-  apptive_grid_core: ^0.10.0
+  apptive_grid_core: ^0.12.0
   flutter:
     sdk: flutter
   http: ^0.13.4

--- a/packages/apptive_grid_web_apptive/CHANGELOG.md
+++ b/packages/apptive_grid_web_apptive/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.4.0
+* Update apptive_grid_core to [0.12.0](https://pub.dev/packages/apptive_grid_core/changelog#0120)
+
 ## 0.3.0
 * Update apptive_grid_core Package to include breaking [Model Changes from Version 0.10.0](https://pub.dev/packages/apptive_grid_core/changelog#0100)
 * Updated example to use [apptive_grid_theme](https://pub.dev/packages/apptive_grid_theme)

--- a/packages/apptive_grid_web_apptive/pubspec.yaml
+++ b/packages/apptive_grid_web_apptive/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_web_apptive
 description: A Flutter Package to enable Flutter Apptives on ApptiveGrid Web Client
-version: 0.0.3
+version: 0.0.4
 homepage: https://apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_web_apptive
 publish_to: none


### PR DESCRIPTION
Improve Attachment Processing Performance

- Add option to add an attachment via a path to a file in addition to only raw bytes
- Perform only one resize operation instead of one per size
- Only process 2 Attachments at once