### PR TITLE
Ac 2050 delete account

### DIFF
--- a/packages/apptive_grid_core/CHANGELOG.md
+++ b/packages/apptive_grid_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.12.1
+* Make `defaultHeaders` in ApptiveGridClient public outside of tests
+* Give access to `authenticator` in ApptiveGridClient
+
 ## 0.12.0
 * Update Attachment Processing
 * Add option to add an attachment with a path to a file instead of only the raw bytes

--- a/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
+++ b/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
@@ -806,4 +806,14 @@ class ApptiveGridClient {
 
     return parseResponse(response);
   }
+
+  /// Perform a call to delete the user's account
+  /// This will return `true` if the account deletion was successful
+  Future<bool> deleteAccount() async {
+    // TODO: Do call to delete the account
+
+    await _authenticator.logout();
+
+    return true;
+  }
 }

--- a/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
+++ b/packages/apptive_grid_core/lib/network/apptive_grid_client.dart
@@ -29,16 +29,17 @@ class ApptiveGridClient {
     http.Client? httpClient,
     ApptiveGridAuthenticator? authenticator,
   }) : _client = httpClient ?? http.Client() {
-    _authenticator = authenticator ??
+    this.authenticator = authenticator ??
         ApptiveGridAuthenticator(options: options, httpClient: _client);
     _attachmentProcessor =
-        AttachmentProcessor(options, _authenticator, httpClient: _client);
+        AttachmentProcessor(options, this.authenticator, httpClient: _client);
   }
 
   /// Configurations
   ApptiveGridOptions options;
 
-  late final ApptiveGridAuthenticator _authenticator;
+  /// The authenticator used to authenticate requests
+  late final ApptiveGridAuthenticator authenticator;
 
   final http.Client _client;
 
@@ -51,13 +52,12 @@ class ApptiveGridClient {
   /// Close the connection on the httpClient
   void dispose() {
     _client.close();
-    _authenticator.dispose();
+    authenticator.dispose();
   }
 
   /// Headers that are used for multiple Calls
-  @visibleForTesting
   Map<String, String> get defaultHeaders => (<String, String?>{
-        HttpHeaders.authorizationHeader: _authenticator.header,
+        HttpHeaders.authorizationHeader: authenticator.header,
         HttpHeaders.contentTypeHeader: ContentType.json,
       }..removeWhere((key, value) => value == null))
           .map((key, value) => MapEntry(key, value!));
@@ -100,7 +100,7 @@ class ApptiveGridClient {
     );
     if (response.statusCode >= 400) {
       if (response.statusCode == 401 && !isRetry) {
-        await _authenticator.checkAuthentication();
+        await authenticator.checkAuthentication();
         return loadForm(
           formUri: formUri,
           uri: uri,
@@ -378,7 +378,7 @@ class ApptiveGridClient {
         await _client.get(gridViewUrl, headers: gridHeaders);
     if (gridViewResponse.statusCode >= 400) {
       if (gridViewResponse.statusCode == 401 && !isRetry) {
-        await _authenticator.checkAuthentication();
+        await authenticator.checkAuthentication();
         return loadGrid(
           uri: uri,
           gridUri: gridUri,
@@ -444,7 +444,7 @@ class ApptiveGridClient {
 
     if (response.statusCode >= 400) {
       if (response.statusCode == 401 && !isRetry) {
-        await _authenticator.checkAuthentication();
+        await authenticator.checkAuthentication();
         return loadEntities<T>(
           uri: uri,
           layout: layout,
@@ -474,7 +474,7 @@ class ApptiveGridClient {
   Future<User> getMe({
     Map<String, String> headers = const {},
   }) async {
-    await _authenticator.checkAuthentication();
+    await authenticator.checkAuthentication();
 
     final url = Uri.parse('${options.environment.url}/api/users/me');
     final response =
@@ -498,7 +498,7 @@ class ApptiveGridClient {
     Map<String, String> headers = const {},
   }) async {
     assert(uri != null || spaceUri != null);
-    await _authenticator.checkAuthentication();
+    await authenticator.checkAuthentication();
 
     final url = _generateApptiveGridUri(uri ?? spaceUri!.uri);
     final response =
@@ -522,7 +522,7 @@ class ApptiveGridClient {
     required GridUri gridUri,
     Map<String, String> headers = const {},
   }) async {
-    await _authenticator.checkAuthentication();
+    await authenticator.checkAuthentication();
 
     final baseUrl = _generateApptiveGridUri(gridUri.uri);
     final url = baseUrl.replace(
@@ -552,7 +552,7 @@ class ApptiveGridClient {
     required GridUri gridUri,
     Map<String, String> headers = const {},
   }) async {
-    await _authenticator.checkAuthentication();
+    await authenticator.checkAuthentication();
 
     final baseUrl = _generateApptiveGridUri(gridUri.uri);
     final url = baseUrl.replace(
@@ -584,7 +584,7 @@ class ApptiveGridClient {
     Map<String, String> headers = const {},
   }) async {
     assert(uri != null || entityUri != null);
-    await _authenticator.checkAuthentication();
+    await authenticator.checkAuthentication();
 
     final url = _generateApptiveGridUri(uri ?? entityUri!.uri);
 
@@ -623,7 +623,7 @@ class ApptiveGridClient {
     ApptiveGridLayout layout = ApptiveGridLayout.field,
   }) async {
     assert(uri != null || entityUri != null);
-    await _authenticator.checkAuthentication();
+    await authenticator.checkAuthentication();
 
     final url = _generateApptiveGridUri(uri ?? entityUri!.uri);
 
@@ -647,27 +647,27 @@ class ApptiveGridClient {
   ///
   /// This will open a Webpage for the User Auth
   Future<Credential?> authenticate() {
-    return _authenticator.authenticate();
+    return authenticator.authenticate();
   }
 
   /// Logs out the user
   Future<void> logout() {
-    return _authenticator.logout();
+    return authenticator.logout();
   }
 
   /// Checks if the User is currently authenticated
-  Future<bool> get isAuthenticated => _authenticator.isAuthenticated;
+  Future<bool> get isAuthenticated => authenticator.isAuthenticated;
 
   /// Checks if the User is currently authenticated with a Token.
   /// Returns true if the user is logged in as a user.
   /// Will return false if there is no authentication set or if the authentication is done using a [ApptiveGridApiKey]
   Future<bool> get isAuthenticatedWithToken =>
-      _authenticator.isAuthenticatedWithToken;
+      authenticator.isAuthenticatedWithToken;
 
   /// Authenticates by setting a token
   /// [tokenResponse] needs to be a JWT
   Future<void> setUserToken(Map<String, dynamic> tokenResponse) async {
-    return _authenticator.setUserToken(tokenResponse);
+    return authenticator.setUserToken(tokenResponse);
   }
 
   /// Updates the Environment for the client and handle necessary changes in the Authenticator
@@ -675,13 +675,13 @@ class ApptiveGridClient {
     final currentRealm = options.environment.authRealm;
 
     if (currentRealm != environment.authRealm) {
-      await _authenticator.logout();
+      await authenticator.logout();
     }
 
     options = options.copyWith(environment: environment);
-    _authenticator.options = options;
+    authenticator.options = options;
     _attachmentProcessor =
-        AttachmentProcessor(options, _authenticator, httpClient: _client);
+        AttachmentProcessor(options, authenticator, httpClient: _client);
   }
 
   /// Tries to send pending [ActionItem]s that are stored in [options.cache]
@@ -790,7 +790,7 @@ class ApptiveGridClient {
 
     if (response.statusCode >= 400) {
       if (response.statusCode == 401 && !isRetry) {
-        await _authenticator.checkAuthentication();
+        await authenticator.checkAuthentication();
         return performApptiveLink(
           link: link,
           body: body,
@@ -805,15 +805,5 @@ class ApptiveGridClient {
     }
 
     return parseResponse(response);
-  }
-
-  /// Perform a call to delete the user's account
-  /// This will return `true` if the account deletion was successful
-  Future<bool> deleteAccount() async {
-    // TODO: Do call to delete the account
-
-    await _authenticator.logout();
-
-    return true;
   }
 }

--- a/packages/apptive_grid_core/pubspec.yaml
+++ b/packages/apptive_grid_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_core
 description: Core Library for ApptiveGrid used to provide general ApptiveGrid functionality to other Packages or Apps
-version: 0.12.0
+version: 0.12.1
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_core
 

--- a/packages/apptive_grid_user_management/CHANGELOG.md
+++ b/packages/apptive_grid_user_management/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.1
+* Add option to delete a user's account
+
 ## 0.1.0
 * Promote to 0.1.0 release
 * Update apptive_grid_core to [0.12.0](https://pub.dev/packages/apptive_grid_core/changelog#0120)

--- a/packages/apptive_grid_user_management/README.md
+++ b/packages/apptive_grid_user_management/README.md
@@ -89,3 +89,35 @@ Card(
       ),
 )
 ```
+
+## Delete Account
+To comply with the Apple Review Guidelines Apps that offer Account Creation also require to provide an option to delete the account. [More Information](https://developer.apple.com/support/offering-account-deletion-in-your-app)
+
+This package provides widgets to show the delete account option.
+
+```dart
+// As a ListTile
+DeleteAccount.listTile(
+  onAccountDeleted: () {
+      // Go to Login Screen, etc...
+  },
+),
+
+// As a TextButton
+DeleteAccount.textButton(
+    onAccountDeleted: () {
+      // Go to Login Screen, etc...
+    },
+),
+
+// As a Custom Widget
+// Note that gesture detectors on your custom widget will be ignored
+DeleteAccount(
+    onAccountDeleted: () {
+      // Go to Login Screen, etc...
+    },
+    child: CustomWidget(),
+),
+```
+
+Clicking on one of these Widgets will show users a dialog where they can confirm that they want to delete their account.

--- a/packages/apptive_grid_user_management/example/lib/main.dart
+++ b/packages/apptive_grid_user_management/example/lib/main.dart
@@ -117,6 +117,15 @@ class LoginRegistrationPage extends StatelessWidget {
               ),
             ),
           ),
+          DeleteAccount.textButton(
+            onAccountDeleted: () {
+              ScaffoldMessenger.of(context).showSnackBar(
+                const SnackBar(
+                  content: Text('Account Deleted'),
+                ),
+              );
+            },
+          ),
         ],
       ),
     );

--- a/packages/apptive_grid_user_management/example/lib/main.dart
+++ b/packages/apptive_grid_user_management/example/lib/main.dart
@@ -48,7 +48,13 @@ class MyApp extends StatelessWidget {
                   content: Text('Account Confirmed. LoggedIn: $loggedIn'),
                 ),
               );
-              _navigatorKey.currentState?.pop();
+              Navigator.of(context).pushReplacement(
+                MaterialPageRoute(
+                  builder: (_) {
+                    return const AccountPage();
+                  },
+                ),
+              );
             },
             resetPasswordPrompt: (resetPasswordWidget) {
               // Show [resetPasswordWidget] to allow Users to set a new password
@@ -109,24 +115,91 @@ class LoginRegistrationPage extends StatelessWidget {
                 child: ApptiveGridUserManagementContent(
                   appName: 'ApptiveGridUserManagement Example',
                   onLogin: () {
-                    ScaffoldMessenger.of(context).showSnackBar(
-                      const SnackBar(content: Text('User logged in')),
+                    Navigator.of(context).pushReplacement(
+                      MaterialPageRoute(
+                        builder: (_) {
+                          return const AccountPage();
+                        },
+                      ),
                     );
                   },
                 ),
               ),
             ),
           ),
-          DeleteAccount.textButton(
-            onAccountDeleted: () {
-              ScaffoldMessenger.of(context).showSnackBar(
-                const SnackBar(
-                  content: Text('Account Deleted'),
-                ),
-              );
-            },
-          ),
         ],
+      ),
+    );
+  }
+}
+
+class AccountPage extends StatefulWidget {
+  const AccountPage({super.key});
+
+  @override
+  State<AccountPage> createState() => _AccountPageState();
+}
+
+class _AccountPageState extends State<AccountPage> {
+  User? _user;
+
+  @override
+  void didChangeDependencies() {
+    super.didChangeDependencies();
+    ApptiveGrid.getClient(context).getMe().then((user) {
+      setState(() {
+        _user = user;
+      });
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Account'),
+      ),
+      body: Builder(
+        builder: (_) {
+          if (_user == null) {
+            return const Center(
+              child: CircularProgressIndicator.adaptive(),
+            );
+          } else {
+            return Column(
+              children: [
+                Text('Logged in as ${_user!.firstName} ${_user!.lastName}'),
+                TextButton(
+                  onPressed: () {
+                    ApptiveGrid.getClient(context, listen: false)
+                        .logout()
+                        .then((_) {
+                      Navigator.of(context).pushReplacement(
+                        MaterialPageRoute(
+                          builder: (_) {
+                            return const LoginRegistrationPage();
+                          },
+                        ),
+                      );
+                    });
+                  },
+                  child: const Text('Logout'),
+                ),
+                DeleteAccount.textButton(
+                  onAccountDeleted: () {
+                    Navigator.of(context).pushReplacement(
+                      MaterialPageRoute(
+                        builder: (_) {
+                          return const LoginRegistrationPage();
+                        },
+                      ),
+                    );
+                  },
+                ),
+              ],
+            );
+          }
+        },
       ),
     );
   }

--- a/packages/apptive_grid_user_management/example/lib/main.dart
+++ b/packages/apptive_grid_user_management/example/lib/main.dart
@@ -187,13 +187,15 @@ class _AccountPageState extends State<AccountPage> {
                 ),
                 DeleteAccount.textButton(
                   onAccountDeleted: () {
-                    Navigator.of(context).pushReplacement(
-                      MaterialPageRoute(
-                        builder: (_) {
-                          return const LoginRegistrationPage();
-                        },
-                      ),
-                    );
+                    WidgetsBinding.instance.addPostFrameCallback((_) {
+                      Navigator.of(context).pushReplacement(
+                        MaterialPageRoute(
+                          builder: (_) {
+                            return const LoginRegistrationPage();
+                          },
+                        ),
+                      );
+                    });
                   },
                 ),
               ],

--- a/packages/apptive_grid_user_management/lib/apptive_grid_user_management.dart
+++ b/packages/apptive_grid_user_management/lib/apptive_grid_user_management.dart
@@ -1,6 +1,8 @@
 library apptive_grid_user_management;
 
 export 'package:apptive_grid_core/apptive_grid_core.dart';
+
 export 'src/apptive_grid_user_management.dart';
 export 'src/apptive_grid_user_management_content.dart';
+export 'src/delete_account.dart';
 export 'src/password_check.dart' show PasswordRequirement;

--- a/packages/apptive_grid_user_management/lib/src/delete_account.dart
+++ b/packages/apptive_grid_user_management/lib/src/delete_account.dart
@@ -1,11 +1,13 @@
 import 'dart:async';
 
 import 'package:apptive_grid_user_management/apptive_grid_user_management.dart';
-import 'package:apptive_grid_user_management/src/loading_notifier.dart';
 import 'package:apptive_grid_user_management/src/translation/apptive_grid_user_management_localization.dart';
 import 'package:flutter/material.dart';
 import 'package:http/http.dart' as http;
 
+part 'package:apptive_grid_user_management/src/loading_notifier.dart';
+
+/// A Widget to give the option to delete an Account
 class DeleteAccount extends StatefulWidget {
   const DeleteAccount._({
     super.key,
@@ -13,6 +15,9 @@ class DeleteAccount extends StatefulWidget {
     required this.onAccountDeleted,
   }) : _child = child;
 
+  /// Wrap [child] in a Gesture Detector that on tap will show a confirmation dialog to delete the user's account
+  /// Note that any Pointer Events will be absorbed by this widget and custom gestures are not possible with [child]
+  /// [onAccountDeleted] will be called if the user's account was deleted successfully
   factory DeleteAccount({
     required Widget child,
     required void Function() onAccountDeleted,
@@ -34,6 +39,8 @@ class DeleteAccount extends StatefulWidget {
     );
   }
 
+  /// A [ListTile] that on tap will show a confirmation dialog to delete the user's account
+  /// [onAccountDeleted] will be called if the user's account was deleted successfully
   factory DeleteAccount.listTile({
     required void Function() onAccountDeleted,
   }) {
@@ -55,6 +62,8 @@ class DeleteAccount extends StatefulWidget {
     );
   }
 
+  /// A [TextButton] that on tap will show a confirmation dialog to delete the user's account
+  /// [onAccountDeleted] will be called if the user's account was deleted successfully
   factory DeleteAccount.textButton({
     required void Function() onAccountDeleted,
   }) {
@@ -79,27 +88,31 @@ class DeleteAccount extends StatefulWidget {
   }
 
   final Widget _child;
+
+  /// A callback invoked when the user's account was deleted
   final void Function() onAccountDeleted;
 
   @override
   State<DeleteAccount> createState() => DeleteAccountState();
 }
 
+/// The State for [DeleteAccount]
 class DeleteAccountState extends State<DeleteAccount> {
   @override
   Widget build(BuildContext context) {
     return widget._child;
   }
 
+  /// Shows an [AlertDialog] to have the user confirm that they want their account deleted
   void showConfirmationDialog(BuildContext context) {
     final localization = ApptiveGridUserManagementLocalization.of(context);
     final client = ApptiveGridUserManagement.maybeOf(context)?.client;
-    final loadingKey = GlobalKey<LoadingStateWidgetState>();
+    final loadingKey = GlobalKey<_LoadingStateWidgetState>();
     showDialog(
       barrierDismissible: false,
       context: context,
       builder: (BuildContext dialogContext) {
-        return LoadingStateWidget(
+        return _LoadingStateWidget(
           key: loadingKey,
           child: Builder(
             builder: (context) {
@@ -113,11 +126,11 @@ class DeleteAccountState extends State<DeleteAccount> {
                       localization?.deleteAccountConfirmation ??
                           'Are you sure you want to delete your account?\n This can not be undone.',
                     ),
-                    if (LoadingStateWidget.error(context) != null)
+                    if (_LoadingStateWidget.error(context) != null)
                       Text(
-                        LoadingStateWidget.error(context) is http.Response
-                            ? '${LoadingStateWidget.error(context).statusCode}: ${LoadingStateWidget.error(context).body}'
-                            : '${localization?.errorUnknown}\n${LoadingStateWidget.error(context)!}',
+                        _LoadingStateWidget.error(context) is http.Response
+                            ? '${_LoadingStateWidget.error(context).statusCode}: ${_LoadingStateWidget.error(context).body}'
+                            : '${localization?.errorUnknown}\n${_LoadingStateWidget.error(context)!}',
                         style: TextStyle(
                           color: Theme.of(context).colorScheme.error,
                         ),
@@ -125,7 +138,7 @@ class DeleteAccountState extends State<DeleteAccount> {
                   ],
                 ),
                 actions: <Widget>[
-                  if (!LoadingStateWidget.isLoading(context))
+                  if (!_LoadingStateWidget.isLoading(context))
                     TextButton(
                       child: Text(localization?.actionCancel ?? 'Cancel'),
                       onPressed: () {
@@ -172,12 +185,12 @@ class _LoadingTextButton extends StatelessWidget {
   });
 
   final Widget child;
-  final GlobalKey<LoadingStateWidgetState> loadingKey;
+  final GlobalKey<_LoadingStateWidgetState> loadingKey;
   final FutureOr<void> Function() onPressed;
 
   @override
   Widget build(BuildContext context) {
-    if (LoadingStateWidget.isLoading(context)) {
+    if (_LoadingStateWidget.isLoading(context)) {
       return const TextButton(
         onPressed: null,
         child: CircularProgressIndicator.adaptive(),

--- a/packages/apptive_grid_user_management/lib/src/delete_account.dart
+++ b/packages/apptive_grid_user_management/lib/src/delete_account.dart
@@ -19,6 +19,7 @@ class DeleteAccount extends StatefulWidget {
   }) {
     final key = GlobalKey<DeleteAccountState>();
     return DeleteAccount._(
+      key: key,
       onAccountDeleted: onAccountDeleted,
       child: Builder(
         builder: (context) {
@@ -26,9 +27,7 @@ class DeleteAccount extends StatefulWidget {
             onTap: () {
               key.currentState?.showConfirmationDialog(context);
             },
-            child: IgnorePointer(
-              child: child,
-            ),
+            child: AbsorbPointer(child: child),
           );
         },
       ),
@@ -114,9 +113,7 @@ class DeleteAccountState extends State<DeleteAccount> {
                       Text(
                         LoadingStateWidget.error(context) is http.Response
                             ? '${LoadingStateWidget.error(context).statusCode}: ${LoadingStateWidget.error(context).body}'
-                            : LoadingStateWidget.error(context)?.toString() ??
-                                localization?.errorUnknown ??
-                                '',
+                            : '${localization?.errorUnknown}\n${LoadingStateWidget.error(context)!}',
                         style: TextStyle(
                           color: Theme.of(context).colorScheme.error,
                         ),

--- a/packages/apptive_grid_user_management/lib/src/delete_account.dart
+++ b/packages/apptive_grid_user_management/lib/src/delete_account.dart
@@ -116,6 +116,7 @@ class DeleteAccountState extends State<DeleteAccount> {
           key: loadingKey,
           child: Builder(
             builder: (context) {
+              final error = _LoadingStateWidget.error(context);
               return AlertDialog(
                 title: Text(localization?.deleteAccount ?? 'Delete Account'),
                 content: Column(
@@ -126,11 +127,11 @@ class DeleteAccountState extends State<DeleteAccount> {
                       localization?.deleteAccountConfirmation ??
                           'Are you sure you want to delete your account?\n This can not be undone.',
                     ),
-                    if (_LoadingStateWidget.error(context) != null)
+                    if (error != null)
                       Text(
-                        _LoadingStateWidget.error(context) is http.Response
-                            ? '${_LoadingStateWidget.error(context).statusCode}: ${_LoadingStateWidget.error(context).body}'
-                            : '${localization?.errorUnknown}\n${_LoadingStateWidget.error(context)!}',
+                        error is http.Response
+                            ? '${error.statusCode}: ${error.body}'
+                            : '${localization?.errorUnknown}\n${error!}',
                         style: TextStyle(
                           color: Theme.of(context).colorScheme.error,
                         ),

--- a/packages/apptive_grid_user_management/lib/src/delete_account.dart
+++ b/packages/apptive_grid_user_management/lib/src/delete_account.dart
@@ -1,0 +1,195 @@
+import 'dart:async';
+
+import 'package:apptive_grid_user_management/apptive_grid_user_management.dart';
+import 'package:apptive_grid_user_management/src/loading_notifier.dart';
+import 'package:apptive_grid_user_management/src/translation/apptive_grid_user_management_localization.dart';
+import 'package:flutter/material.dart';
+import 'package:http/http.dart' as http;
+
+class DeleteAccount extends StatefulWidget {
+  const DeleteAccount._({
+    super.key,
+    required Widget child,
+    required this.onAccountDeleted,
+  }) : _child = child;
+
+  factory DeleteAccount({
+    required Widget child,
+    required void Function() onAccountDeleted,
+  }) {
+    final key = GlobalKey<DeleteAccountState>();
+    return DeleteAccount._(
+      onAccountDeleted: onAccountDeleted,
+      child: Builder(
+        builder: (context) {
+          return GestureDetector(
+            onTap: () {
+              key.currentState?.showConfirmationDialog(context);
+            },
+            child: IgnorePointer(
+              child: child,
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  factory DeleteAccount.listTile({
+    required void Function() onAccountDeleted,
+  }) {
+    final key = GlobalKey<DeleteAccountState>();
+    return DeleteAccount._(
+      key: key,
+      onAccountDeleted: onAccountDeleted,
+      child: Builder(
+        builder: (context) {
+          return ListTile(
+            onTap: () => key.currentState?.showConfirmationDialog(context),
+            title: Text(
+              ApptiveGridUserManagementLocalization.of(context)!.deleteAccount,
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  factory DeleteAccount.textButton({
+    required void Function() onAccountDeleted,
+  }) {
+    final key = GlobalKey<DeleteAccountState>();
+    return DeleteAccount._(
+      key: key,
+      onAccountDeleted: onAccountDeleted,
+      child: Builder(
+        builder: (context) {
+          return TextButton(
+            onPressed: () => key.currentState?.showConfirmationDialog(context),
+            child: Text(
+              ApptiveGridUserManagementLocalization.of(context)!.deleteAccount,
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  final Widget _child;
+  final void Function() onAccountDeleted;
+
+  @override
+  State<DeleteAccount> createState() => DeleteAccountState();
+}
+
+class DeleteAccountState extends State<DeleteAccount> {
+  @override
+  Widget build(BuildContext context) {
+    return widget._child;
+  }
+
+  void showConfirmationDialog(BuildContext context) {
+    final localization = ApptiveGridUserManagementLocalization.of(context);
+    final client = ApptiveGridUserManagement.maybeOf(context)?.client;
+    final loadingey = GlobalKey<LoadingStateWidgetState>();
+    showDialog(
+      barrierDismissible: false,
+      context: context,
+      builder: (BuildContext dialogContext) {
+        return LoadingStateWidget(
+          key: loadingey,
+          child: Builder(
+            builder: (context) {
+              return AlertDialog(
+                title: Text(localization?.deleteAccount ?? 'Delete Account'),
+                content: Column(
+                  mainAxisSize: MainAxisSize.min,
+                  crossAxisAlignment: CrossAxisAlignment.stretch,
+                  children: [
+                    Text(
+                      localization?.deleteAccountConfirmation ??
+                          'Are you sure you want to delete your account?\n This can not be undone.',
+                    ),
+                    if (LoadingStateWidget.error(context) != null)
+                      Text(
+                        LoadingStateWidget.error(context) is http.Response
+                            ? '${LoadingStateWidget.error(context).statusCode}: ${LoadingStateWidget.error(context).body}'
+                            : LoadingStateWidget.error(context)?.toString() ??
+                                localization?.errorUnknown ??
+                                '',
+                        style: TextStyle(
+                          color: Theme.of(context).colorScheme.error,
+                        ),
+                      ),
+                  ],
+                ),
+                actions: <Widget>[
+                  if (!LoadingStateWidget.isLoading(context))
+                    TextButton(
+                      child: Text(localization?.actionCancel ?? 'Cancel'),
+                      onPressed: () {
+                        Navigator.of(context).pop();
+                      },
+                    ),
+                  _LoadingTextButton(
+                    loadingKey: loadingey,
+                    onPressed: () async {
+                      final deleted = await client
+                          ?.deleteAccount()
+                          .onError((error, stackTrace) {
+                        loadingey.currentState?.error = error;
+                        loadingey.currentState?.loading = false;
+                        return false;
+                      });
+                      if (deleted == true) {
+                        widget.onAccountDeleted();
+                        if (mounted) {
+                          Navigator.of(context).pop();
+                        }
+                      }
+                    },
+                    child: Text(
+                      localization?.actionDelete ?? 'Delete',
+                      style: TextStyle(color: Theme.of(context).errorColor),
+                    ),
+                  ),
+                ],
+              );
+            },
+          ),
+        );
+      },
+    );
+  }
+}
+
+class _LoadingTextButton extends StatelessWidget {
+  const _LoadingTextButton({
+    required this.child,
+    required this.loadingKey,
+    required this.onPressed,
+  });
+
+  final Widget child;
+  final GlobalKey<LoadingStateWidgetState> loadingKey;
+  final FutureOr<void> Function() onPressed;
+
+  @override
+  Widget build(BuildContext context) {
+    if (LoadingStateWidget.isLoading(context)) {
+      return const TextButton(
+        onPressed: null,
+        child: CircularProgressIndicator.adaptive(),
+      );
+    } else {
+      return TextButton(
+        onPressed: () async {
+          loadingKey.currentState?.loading = true;
+          await onPressed();
+          loadingKey.currentState?.loading = false;
+        },
+        child: child,
+      );
+    }
+  }
+}

--- a/packages/apptive_grid_user_management/lib/src/delete_account.dart
+++ b/packages/apptive_grid_user_management/lib/src/delete_account.dart
@@ -47,6 +47,7 @@ class DeleteAccount extends StatefulWidget {
             onTap: () => key.currentState?.showConfirmationDialog(context),
             title: Text(
               ApptiveGridUserManagementLocalization.of(context)!.deleteAccount,
+              style: TextStyle(color: Theme.of(context).colorScheme.error),
             ),
           );
         },
@@ -67,6 +68,9 @@ class DeleteAccount extends StatefulWidget {
             onPressed: () => key.currentState?.showConfirmationDialog(context),
             child: Text(
               ApptiveGridUserManagementLocalization.of(context)!.deleteAccount,
+              style: TextStyle(
+                color: Theme.of(context).colorScheme.error,
+              ),
             ),
           );
         },
@@ -90,13 +94,13 @@ class DeleteAccountState extends State<DeleteAccount> {
   void showConfirmationDialog(BuildContext context) {
     final localization = ApptiveGridUserManagementLocalization.of(context);
     final client = ApptiveGridUserManagement.maybeOf(context)?.client;
-    final loadingey = GlobalKey<LoadingStateWidgetState>();
+    final loadingKey = GlobalKey<LoadingStateWidgetState>();
     showDialog(
       barrierDismissible: false,
       context: context,
       builder: (BuildContext dialogContext) {
         return LoadingStateWidget(
-          key: loadingey,
+          key: loadingKey,
           child: Builder(
             builder: (context) {
               return AlertDialog(
@@ -129,13 +133,13 @@ class DeleteAccountState extends State<DeleteAccount> {
                       },
                     ),
                   _LoadingTextButton(
-                    loadingKey: loadingey,
+                    loadingKey: loadingKey,
                     onPressed: () async {
                       final deleted = await client
                           ?.deleteAccount()
                           .onError((error, stackTrace) {
-                        loadingey.currentState?.error = error;
-                        loadingey.currentState?.loading = false;
+                        loadingKey.currentState?.error = error;
+                        loadingKey.currentState?.loading = false;
                         return false;
                       });
                       if (deleted == true) {

--- a/packages/apptive_grid_user_management/lib/src/loading_notifier.dart
+++ b/packages/apptive_grid_user_management/lib/src/loading_notifier.dart
@@ -1,12 +1,12 @@
-import 'package:flutter/material.dart';
+part of 'package:apptive_grid_user_management/src/delete_account.dart';
 
-class LoadingStateWidget extends StatefulWidget {
-  const LoadingStateWidget({super.key, required this.child});
+class _LoadingStateWidget extends StatefulWidget {
+  const _LoadingStateWidget({super.key, required this.child});
 
   final Widget child;
 
   @override
-  State<LoadingStateWidget> createState() => LoadingStateWidgetState();
+  State<_LoadingStateWidget> createState() => _LoadingStateWidgetState();
 
   static bool isLoading(BuildContext context) {
     final state =
@@ -21,7 +21,7 @@ class LoadingStateWidget extends StatefulWidget {
   }
 }
 
-class LoadingStateWidgetState extends State<LoadingStateWidget> {
+class _LoadingStateWidgetState extends State<_LoadingStateWidget> {
   bool _loading = false;
   dynamic _error;
 

--- a/packages/apptive_grid_user_management/lib/src/loading_notifier.dart
+++ b/packages/apptive_grid_user_management/lib/src/loading_notifier.dart
@@ -43,13 +43,19 @@ class LoadingStateWidgetState extends State<LoadingStateWidget> {
   @override
   Widget build(BuildContext context) {
     return _InheritedLoadingState(
-        loading: _loading, error: _error, child: widget.child);
+      loading: _loading,
+      error: _error,
+      child: widget.child,
+    );
   }
 }
 
 class _InheritedLoadingState extends InheritedWidget {
-  const _InheritedLoadingState(
-      {required this.loading, required this.error, required super.child});
+  const _InheritedLoadingState({
+    required this.loading,
+    required this.error,
+    required super.child,
+  });
 
   final bool loading;
   final dynamic error;

--- a/packages/apptive_grid_user_management/lib/src/loading_notifier.dart
+++ b/packages/apptive_grid_user_management/lib/src/loading_notifier.dart
@@ -1,0 +1,61 @@
+import 'package:flutter/material.dart';
+
+class LoadingStateWidget extends StatefulWidget {
+  const LoadingStateWidget({super.key, required this.child});
+
+  final Widget child;
+
+  @override
+  State<LoadingStateWidget> createState() => LoadingStateWidgetState();
+
+  static bool isLoading(BuildContext context) {
+    final state =
+        context.dependOnInheritedWidgetOfExactType<_InheritedLoadingState>();
+    return state?.loading ?? false;
+  }
+
+  static dynamic error(BuildContext context) {
+    final state =
+        context.dependOnInheritedWidgetOfExactType<_InheritedLoadingState>();
+    return state?.error;
+  }
+}
+
+class LoadingStateWidgetState extends State<LoadingStateWidget> {
+  bool _loading = false;
+  dynamic _error;
+
+  set loading(bool value) {
+    setState(() {
+      _loading = value;
+      if (value) {
+        _error = null;
+      }
+    });
+  }
+
+  set error(dynamic value) {
+    setState(() {
+      _error = value;
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return _InheritedLoadingState(
+        loading: _loading, error: _error, child: widget.child);
+  }
+}
+
+class _InheritedLoadingState extends InheritedWidget {
+  const _InheritedLoadingState(
+      {required this.loading, required this.error, required super.child});
+
+  final bool loading;
+  final dynamic error;
+
+  @override
+  bool updateShouldNotify(covariant _InheritedLoadingState oldWidget) {
+    return loading != oldWidget.loading || error != oldWidget.error;
+  }
+}

--- a/packages/apptive_grid_user_management/lib/src/translation/apptive_grid_user_management_translation.dart
+++ b/packages/apptive_grid_user_management/lib/src/translation/apptive_grid_user_management_translation.dart
@@ -107,4 +107,10 @@ abstract class ApptiveGridUserManagementTranslation {
 
   /// Action to join this group
   String get actionJoinGroup;
+
+  String get deleteAccount;
+
+  String get deleteAccountConfirmation;
+
+  String get actionDelete;
 }

--- a/packages/apptive_grid_user_management/lib/src/translation/apptive_grid_user_management_translation.dart
+++ b/packages/apptive_grid_user_management/lib/src/translation/apptive_grid_user_management_translation.dart
@@ -108,9 +108,12 @@ abstract class ApptiveGridUserManagementTranslation {
   /// Action to join this group
   String get actionJoinGroup;
 
+  /// Message to delete an Account
   String get deleteAccount;
 
+  /// Message shown to users to ask to confirm the deletion of their account. Moting, that this can not be undone
   String get deleteAccountConfirmation;
 
+  /// Action to delete something
   String get actionDelete;
 }

--- a/packages/apptive_grid_user_management/lib/src/translation/l10n/intl_de.json
+++ b/packages/apptive_grid_user_management/lib/src/translation/l10n/intl_de.json
@@ -32,5 +32,8 @@
     "registerConfirmAddToGroup": "Es existiert bereits ein Account mit der Adresse $email.\\nWir haben dir einen Link geschickt, mit dem du bestätigen kannst, dass du den Account für \"$app\" freischalten möchtest.\\nDein Passwort wurde nicht geändert.",
     "actionBack": "Zurück",
     "joinGroup": "Dein Account ist noch nicht für $app freigeschaltet.\\nWillst du deinen Account jetzt freischalten?",
-    "actionJoinGroup": "Freischalten"
+    "actionJoinGroup": "Freischalten",
+    "deleteAccount": "Account löschen",
+    "deleteAccountConfirmation": "Bist du sicher, dass du deinen Account löschen möchtest?\\nDies kann nicht rückgängig gemacht werden.",
+    "actionDelete": "Löschen"
 }

--- a/packages/apptive_grid_user_management/lib/src/translation/l10n/intl_en.json
+++ b/packages/apptive_grid_user_management/lib/src/translation/l10n/intl_en.json
@@ -32,5 +32,8 @@
     "registerConfirmAddToGroup": "There already exists an account for $email.\\nWe have send you a link to confirm that you want to activate the account for \"$app\".\\nYour password has not been changed.",
     "actionBack": "Back",
     "joinGroup": "Your account is not yet activated for $app.\\nDo you want to activate it now?",
-    "actionJoinGroup": "Activate"
+    "actionJoinGroup": "Activate",
+    "deleteAccount": "Delete Account",
+    "deleteAccountConfirmation": "Are you sure you want to delete your account?\\nThis can not be undone.",
+    "actionDelete": "Delete"
 }

--- a/packages/apptive_grid_user_management/lib/src/translation/l10n/translation_de.dart
+++ b/packages/apptive_grid_user_management/lib/src/translation/l10n/translation_de.dart
@@ -89,4 +89,11 @@ class ApptiveGridUserManagementLocalizedTranslation
       'Dein Account ist noch nicht für $app freigeschaltet.\nWillst du deinen Account jetzt freischalten?';
   @override
   String get actionJoinGroup => 'Freischalten';
+  @override
+  String get deleteAccount => 'Account löschen';
+  @override
+  String get deleteAccountConfirmation =>
+      'Bist du sicher, dass du deinen Account löschen möchtest?\nDies kann nicht rückgängig gemacht werden.';
+  @override
+  String get actionDelete => 'Löschen';
 }

--- a/packages/apptive_grid_user_management/lib/src/translation/l10n/translation_en.dart
+++ b/packages/apptive_grid_user_management/lib/src/translation/l10n/translation_en.dart
@@ -82,4 +82,11 @@ class ApptiveGridUserManagementLocalizedTranslation
       'Your account is not yet activated for $app.\nDo you want to activate it now?';
   @override
   String get actionJoinGroup => 'Activate';
+  @override
+  String get deleteAccount => 'Delete Account';
+  @override
+  String get deleteAccountConfirmation =>
+      'Are you sure you want to delete your account?\nThis can not be undone.';
+  @override
+  String get actionDelete => 'Delete';
 }

--- a/packages/apptive_grid_user_management/lib/src/user_management_client.dart
+++ b/packages/apptive_grid_user_management/lib/src/user_management_client.dart
@@ -193,7 +193,7 @@ class ApptiveGridUserManagementClient {
     await apptiveGridClient.authenticator.checkAuthentication();
     final deleteResponse = await _client.delete(
       Uri.parse(
-        '${apptiveGridClient.options.environment.url}/auth/$group/users/me?clientId=$clientId',
+        '${apptiveGridClient.options.environment.url}/auth/$group/users/me',
       ),
       headers: apptiveGridClient.defaultHeaders,
     );

--- a/packages/apptive_grid_user_management/lib/src/user_management_client.dart
+++ b/packages/apptive_grid_user_management/lib/src/user_management_client.dart
@@ -181,4 +181,11 @@ class ApptiveGridUserManagementClient {
       return response;
     }
   }
+
+  /// Perform a call to delete the user's account
+  /// This will return `true` if the account deletion was successful
+  Future<bool> deleteAccount() async {
+    await Future.delayed(const Duration(seconds: 4));
+    return apptiveGridClient.deleteAccount();
+  }
 }

--- a/packages/apptive_grid_user_management/lib/src/user_management_client.dart
+++ b/packages/apptive_grid_user_management/lib/src/user_management_client.dart
@@ -186,6 +186,8 @@ class ApptiveGridUserManagementClient {
   /// This will return `true` if the account deletion was successful
   Future<bool> deleteAccount() async {
     await Future.delayed(const Duration(seconds: 4));
+    // TODO: Perform call or return false if the call failed
+    // Clarify if the call is made against /auth/ then do it directly here otherwise call a function in the client
     return apptiveGridClient.deleteAccount();
   }
 }

--- a/packages/apptive_grid_user_management/lib/src/user_management_client.dart
+++ b/packages/apptive_grid_user_management/lib/src/user_management_client.dart
@@ -188,6 +188,6 @@ class ApptiveGridUserManagementClient {
     await Future.delayed(const Duration(seconds: 4));
     // TODO: Perform call or return false if the call failed
     // Clarify if the call is made against /auth/ then do it directly here otherwise call a function in the client
-    return apptiveGridClient.deleteAccount();
+    return false;
   }
 }

--- a/packages/apptive_grid_user_management/lib/src/user_management_client.dart
+++ b/packages/apptive_grid_user_management/lib/src/user_management_client.dart
@@ -185,9 +185,23 @@ class ApptiveGridUserManagementClient {
   /// Perform a call to delete the user's account
   /// This will return `true` if the account deletion was successful
   Future<bool> deleteAccount() async {
-    await Future.delayed(const Duration(seconds: 4));
-    // TODO: Perform call or return false if the call failed
-    // Clarify if the call is made against /auth/ then do it directly here otherwise call a function in the client
-    return false;
+    final isAuthenticated = await apptiveGridClient.isAuthenticatedWithToken;
+
+    if (!isAuthenticated) {
+      return false;
+    }
+    await apptiveGridClient.authenticator.checkAuthentication();
+    final deleteResponse = await _client.delete(
+      Uri.parse(
+        '${apptiveGridClient.options.environment.url}/auth/$group/users/me',
+      ),
+      headers: apptiveGridClient.defaultHeaders,
+    );
+
+    if (deleteResponse.statusCode >= 400) {
+      throw deleteResponse;
+    } else {
+      return true;
+    }
   }
 }

--- a/packages/apptive_grid_user_management/lib/src/user_management_client.dart
+++ b/packages/apptive_grid_user_management/lib/src/user_management_client.dart
@@ -193,7 +193,7 @@ class ApptiveGridUserManagementClient {
     await apptiveGridClient.authenticator.checkAuthentication();
     final deleteResponse = await _client.delete(
       Uri.parse(
-        '${apptiveGridClient.options.environment.url}/auth/$group/users/me',
+        '${apptiveGridClient.options.environment.url}/auth/$group/users/me?clientId=$clientId',
       ),
       headers: apptiveGridClient.defaultHeaders,
     );

--- a/packages/apptive_grid_user_management/pubspec.yaml
+++ b/packages/apptive_grid_user_management/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_user_management
-description: Package to add UserManagement through ApptiveGrid to a Flutter App. This provides Login/Register Widgets and options to confirm accoutns
-version: 0.1.0
+description: Package to add UserManagement through ApptiveGrid to a Flutter App. This provides Login/Register Widgets and options to confirm accounts
+version: 0.1.1
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_user_management
 

--- a/packages/apptive_grid_user_management/test/infrastructure/mocks.dart
+++ b/packages/apptive_grid_user_management/test/infrastructure/mocks.dart
@@ -1,7 +1,7 @@
 import 'package:apptive_grid_core/apptive_grid_core.dart';
+import 'package:apptive_grid_user_management/src/user_management_client.dart';
 import 'package:http/http.dart';
 import 'package:mocktail/mocktail.dart';
-import 'package:apptive_grid_user_management/src/user_management_client.dart';
 import 'package:plugin_platform_interface/plugin_platform_interface.dart';
 import 'package:uni_links_platform_interface/uni_links_platform_interface.dart';
 
@@ -13,5 +13,7 @@ class MockUniLinks extends Mock
     implements UniLinksPlatform {}
 
 class MockApptiveGridClient extends Mock implements ApptiveGridClient {}
+
+class MockAuthenticator extends Mock implements ApptiveGridAuthenticator {}
 
 class MockHttpClient extends Mock implements Client {}

--- a/packages/apptive_grid_user_management/test/src/apptive_grid_user_management_client_test.dart
+++ b/packages/apptive_grid_user_management/test/src/apptive_grid_user_management_client_test.dart
@@ -707,8 +707,8 @@ void main() {
   group('Delete Account', () {
     const clientId = 'clientId';
     const group = 'group';
-    final deleteUri = Uri.parse(
-        'https://app.apptivegrid.de/auth/$group/users/me?clientId=$clientId');
+    final deleteUri =
+        Uri.parse('https://app.apptivegrid.de/auth/$group/users/me');
 
     test('Delete Account successfully', () async {
       const group = 'group';

--- a/packages/apptive_grid_user_management/test/src/apptive_grid_user_management_client_test.dart
+++ b/packages/apptive_grid_user_management/test/src/apptive_grid_user_management_client_test.dart
@@ -703,4 +703,138 @@ void main() {
       );
     });
   });
+
+  group('Delete Account', () {
+    test('Delete Account successfully', () async {
+      const group = 'group';
+      final authenticator = MockAuthenticator();
+      when(() => authenticator.checkAuthentication()).thenAnswer((_) async {});
+
+      final apptiveGridClient = MockApptiveGridClient();
+      when(() => apptiveGridClient.options)
+          .thenReturn(const ApptiveGridOptions());
+      when(() => apptiveGridClient.isAuthenticatedWithToken)
+          .thenAnswer((_) async => true);
+      when(() => apptiveGridClient.defaultHeaders).thenReturn({
+        'Authentication': 'Bearer token',
+      });
+      when(() => apptiveGridClient.authenticator).thenReturn(authenticator);
+
+      final httpClient = MockHttpClient();
+      when(() => httpClient.delete(
+              Uri.parse('https://app.apptivegrid.de/auth/$group/users/me'),
+              headers: any(named: 'headers')))
+          .thenAnswer((_) async => Response('', 200));
+
+      final userManagementClient = ApptiveGridUserManagementClient(
+        group: group,
+        clientId: 'app',
+        apptiveGridClient: apptiveGridClient,
+        client: httpClient,
+      );
+
+      expect(await userManagementClient.deleteAccount(), true);
+      verify(() => httpClient.delete(
+          Uri.parse('https://app.apptivegrid.de/auth/$group/users/me'),
+          headers: any(named: 'headers'))).called(1);
+    });
+
+    test('Delete Account Throws Error', () async {
+      const group = 'group';
+      final authenticator = MockAuthenticator();
+      when(() => authenticator.checkAuthentication()).thenAnswer((_) async {});
+
+      final apptiveGridClient = MockApptiveGridClient();
+      when(() => apptiveGridClient.options)
+          .thenReturn(const ApptiveGridOptions());
+      when(() => apptiveGridClient.isAuthenticatedWithToken)
+          .thenAnswer((_) async => true);
+      when(() => apptiveGridClient.defaultHeaders).thenReturn({
+        'Authentication': 'Bearer token',
+      });
+      when(() => apptiveGridClient.authenticator).thenReturn(authenticator);
+
+      final httpClient = MockHttpClient();
+      when(() => httpClient.delete(
+              Uri.parse('https://app.apptivegrid.de/auth/$group/users/me'),
+              headers: any(named: 'headers')))
+          .thenAnswer((_) async => Future.error(Exception('Error')));
+
+      final userManagementClient = ApptiveGridUserManagementClient(
+        group: group,
+        clientId: 'app',
+        apptiveGridClient: apptiveGridClient,
+        client: httpClient,
+      );
+
+      expect(() => userManagementClient.deleteAccount(), throwsException);
+    });
+
+    test('Delete Account Throws Response if StatusCode >= 400', () async {
+      const group = 'group';
+      final authenticator = MockAuthenticator();
+      when(() => authenticator.checkAuthentication()).thenAnswer((_) async {});
+
+      final apptiveGridClient = MockApptiveGridClient();
+      when(() => apptiveGridClient.options)
+          .thenReturn(const ApptiveGridOptions());
+      when(() => apptiveGridClient.isAuthenticatedWithToken)
+          .thenAnswer((_) async => true);
+      when(() => apptiveGridClient.defaultHeaders).thenReturn({
+        'Authentication': 'Bearer token',
+      });
+      when(() => apptiveGridClient.authenticator).thenReturn(authenticator);
+
+      final httpClient = MockHttpClient();
+      when(() => httpClient.delete(
+              Uri.parse('https://app.apptivegrid.de/auth/$group/users/me'),
+              headers: any(named: 'headers')))
+          .thenAnswer((_) async => Response('body', 400));
+
+      final userManagementClient = ApptiveGridUserManagementClient(
+        group: group,
+        clientId: 'app',
+        apptiveGridClient: apptiveGridClient,
+        client: httpClient,
+      );
+
+      expect(
+          () => userManagementClient.deleteAccount(), throwsA(isA<Response>()));
+    });
+
+    test('Delete Account returns false if not authenticated', () async {
+      const group = 'group';
+
+      final authenticator = MockAuthenticator();
+      when(() => authenticator.checkAuthentication()).thenAnswer((_) async {});
+
+      final apptiveGridClient = MockApptiveGridClient();
+      when(() => apptiveGridClient.options)
+          .thenReturn(const ApptiveGridOptions());
+      when(() => apptiveGridClient.isAuthenticatedWithToken)
+          .thenAnswer((_) async => false);
+      when(() => apptiveGridClient.defaultHeaders).thenReturn({
+        'Authentication': 'Bearer token',
+      });
+      when(() => apptiveGridClient.authenticator).thenReturn(authenticator);
+
+      final httpClient = MockHttpClient();
+      when(() => httpClient.delete(
+              Uri.parse('https://app.apptivegrid.de/auth/$group/users/me'),
+              headers: any(named: 'headers')))
+          .thenAnswer((_) async => Future.error(Exception('Error')));
+
+      final userManagementClient = ApptiveGridUserManagementClient(
+        group: group,
+        clientId: 'app',
+        apptiveGridClient: apptiveGridClient,
+        client: httpClient,
+      );
+
+      expect(await userManagementClient.deleteAccount(), false);
+      verifyNever(() => httpClient.delete(
+          Uri.parse('https://app.apptivegrid.de/auth/$group/users/me'),
+          headers: any(named: 'headers')));
+    });
+  });
 }

--- a/packages/apptive_grid_user_management/test/src/apptive_grid_user_management_client_test.dart
+++ b/packages/apptive_grid_user_management/test/src/apptive_grid_user_management_client_test.dart
@@ -796,7 +796,9 @@ void main() {
       );
 
       expect(
-          () => userManagementClient.deleteAccount(), throwsA(isA<Response>()));
+        () => userManagementClient.deleteAccount(),
+        throwsA(isA<Response>()),
+      );
     });
 
     test('Delete Account returns false if not authenticated', () async {
@@ -828,7 +830,8 @@ void main() {
 
       expect(await userManagementClient.deleteAccount(), false);
       verifyNever(
-          () => httpClient.delete(deleteUri, headers: any(named: 'headers')));
+        () => httpClient.delete(deleteUri, headers: any(named: 'headers')),
+      );
     });
   });
 }

--- a/packages/apptive_grid_user_management/test/src/apptive_grid_user_management_client_test.dart
+++ b/packages/apptive_grid_user_management/test/src/apptive_grid_user_management_client_test.dart
@@ -705,6 +705,11 @@ void main() {
   });
 
   group('Delete Account', () {
+    const clientId = 'clientId';
+    const group = 'group';
+    final deleteUri = Uri.parse(
+        'https://app.apptivegrid.de/auth/$group/users/me?clientId=$clientId');
+
     test('Delete Account successfully', () async {
       const group = 'group';
       final authenticator = MockAuthenticator();
@@ -721,26 +726,22 @@ void main() {
       when(() => apptiveGridClient.authenticator).thenReturn(authenticator);
 
       final httpClient = MockHttpClient();
-      when(() => httpClient.delete(
-              Uri.parse('https://app.apptivegrid.de/auth/$group/users/me'),
-              headers: any(named: 'headers')))
+      when(() => httpClient.delete(deleteUri, headers: any(named: 'headers')))
           .thenAnswer((_) async => Response('', 200));
 
       final userManagementClient = ApptiveGridUserManagementClient(
         group: group,
-        clientId: 'app',
+        clientId: clientId,
         apptiveGridClient: apptiveGridClient,
         client: httpClient,
       );
 
       expect(await userManagementClient.deleteAccount(), true);
-      verify(() => httpClient.delete(
-          Uri.parse('https://app.apptivegrid.de/auth/$group/users/me'),
-          headers: any(named: 'headers'))).called(1);
+      verify(() => httpClient.delete(deleteUri, headers: any(named: 'headers')))
+          .called(1);
     });
 
     test('Delete Account Throws Error', () async {
-      const group = 'group';
       final authenticator = MockAuthenticator();
       when(() => authenticator.checkAuthentication()).thenAnswer((_) async {});
 
@@ -755,14 +756,12 @@ void main() {
       when(() => apptiveGridClient.authenticator).thenReturn(authenticator);
 
       final httpClient = MockHttpClient();
-      when(() => httpClient.delete(
-              Uri.parse('https://app.apptivegrid.de/auth/$group/users/me'),
-              headers: any(named: 'headers')))
+      when(() => httpClient.delete(deleteUri, headers: any(named: 'headers')))
           .thenAnswer((_) async => Future.error(Exception('Error')));
 
       final userManagementClient = ApptiveGridUserManagementClient(
         group: group,
-        clientId: 'app',
+        clientId: clientId,
         apptiveGridClient: apptiveGridClient,
         client: httpClient,
       );
@@ -786,14 +785,12 @@ void main() {
       when(() => apptiveGridClient.authenticator).thenReturn(authenticator);
 
       final httpClient = MockHttpClient();
-      when(() => httpClient.delete(
-              Uri.parse('https://app.apptivegrid.de/auth/$group/users/me'),
-              headers: any(named: 'headers')))
+      when(() => httpClient.delete(deleteUri, headers: any(named: 'headers')))
           .thenAnswer((_) async => Response('body', 400));
 
       final userManagementClient = ApptiveGridUserManagementClient(
         group: group,
-        clientId: 'app',
+        clientId: clientId,
         apptiveGridClient: apptiveGridClient,
         client: httpClient,
       );
@@ -819,22 +816,19 @@ void main() {
       when(() => apptiveGridClient.authenticator).thenReturn(authenticator);
 
       final httpClient = MockHttpClient();
-      when(() => httpClient.delete(
-              Uri.parse('https://app.apptivegrid.de/auth/$group/users/me'),
-              headers: any(named: 'headers')))
+      when(() => httpClient.delete(deleteUri, headers: any(named: 'headers')))
           .thenAnswer((_) async => Future.error(Exception('Error')));
 
       final userManagementClient = ApptiveGridUserManagementClient(
         group: group,
-        clientId: 'app',
+        clientId: clientId,
         apptiveGridClient: apptiveGridClient,
         client: httpClient,
       );
 
       expect(await userManagementClient.deleteAccount(), false);
-      verifyNever(() => httpClient.delete(
-          Uri.parse('https://app.apptivegrid.de/auth/$group/users/me'),
-          headers: any(named: 'headers')));
+      verifyNever(
+          () => httpClient.delete(deleteUri, headers: any(named: 'headers')));
     });
   });
 }

--- a/packages/apptive_grid_user_management/test/src/delete_account_test.dart
+++ b/packages/apptive_grid_user_management/test/src/delete_account_test.dart
@@ -1,0 +1,189 @@
+import 'dart:async';
+
+import 'package:apptive_grid_user_management/src/delete_account.dart';
+import 'package:flutter/material.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:http/http.dart' as http;
+import 'package:mocktail/mocktail.dart';
+
+import '../infrastructure/mocks.dart';
+import '../infrastructure/test_app.dart';
+
+void main() {
+  final client = MockApptiveGridUserManagementClient();
+
+  setUp(() {
+    when(() => client.deleteAccount()).thenAnswer((_) async => true);
+  });
+
+  testWidgets('Delete Account', (tester) async {
+    final completer = Completer<bool>();
+    final target = StubUserManagement(
+      client: client,
+      child: DeleteAccount.textButton(
+        onAccountDeleted: () => completer.complete(true),
+      ),
+    );
+
+    await tester.pumpWidget(target);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DeleteAccount));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    await tester.tap(find.text('Delete'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsNothing);
+    verify(() => client.deleteAccount()).called(1);
+    expect(await completer.future, true);
+  });
+
+  testWidgets('Delete Account List Tile', (tester) async {
+    final completer = Completer<bool>();
+    final target = StubUserManagement(
+      client: client,
+      child: DeleteAccount.listTile(
+        onAccountDeleted: () => completer.complete(true),
+      ),
+    );
+
+    await tester.pumpWidget(target);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DeleteAccount));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    await tester.tap(find.text('Delete'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsNothing);
+    verify(() => client.deleteAccount()).called(1);
+    expect(await completer.future, true);
+  });
+
+  testWidgets('Delete Account with custom widget', (tester) async {
+    final completer = Completer<bool>();
+    final target = StubUserManagement(
+      client: client,
+      child: DeleteAccount(
+        onAccountDeleted: () => completer.complete(true),
+        child: const Text('Custom Widget'),
+      ),
+    );
+
+    await tester.pumpWidget(target);
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.descendant(
+        of: find.byType(DeleteAccount),
+        matching: find.byType(GestureDetector),
+      ),
+      warnIfMissed: false,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    await tester.tap(find.text('Delete'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsNothing);
+    verify(() => client.deleteAccount()).called(1);
+    expect(await completer.future, true);
+  });
+
+  testWidgets('Delete Account shows Error', (tester) async {
+    when(client.deleteAccount).thenAnswer((_) => Future.error('Error'));
+    final target = StubUserManagement(
+      client: client,
+      child: DeleteAccount(
+        onAccountDeleted: () => {},
+        child: const Text('Custom Widget'),
+      ),
+    );
+
+    await tester.pumpWidget(target);
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.descendant(
+        of: find.byType(DeleteAccount),
+        matching: find.byType(GestureDetector),
+      ),
+      warnIfMissed: false,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    await tester.tap(find.text('Delete'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+    verify(() => client.deleteAccount()).called(1);
+    expect(
+      find.text('An error occurred. Please try again.\nError'),
+      findsOneWidget,
+    );
+  });
+
+  testWidgets('Delete Account Error with Reponse shows Body', (tester) async {
+    when(client.deleteAccount)
+        .thenAnswer((_) => Future.error(http.Response('Error', 400)));
+    final target = StubUserManagement(
+      client: client,
+      child: DeleteAccount(
+        onAccountDeleted: () => {},
+        child: const Text('Custom Widget'),
+      ),
+    );
+
+    await tester.pumpWidget(target);
+    await tester.pumpAndSettle();
+
+    await tester.tap(
+      find.descendant(
+        of: find.byType(DeleteAccount),
+        matching: find.byType(GestureDetector),
+      ),
+      warnIfMissed: false,
+    );
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    await tester.tap(find.text('Delete'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+    verify(() => client.deleteAccount()).called(1);
+    expect(find.text('400: Error'), findsOneWidget);
+  });
+
+  testWidgets('Delete Account Cancel Dialog', (tester) async {
+    final target = StubUserManagement(
+      client: client,
+      child: DeleteAccount.listTile(onAccountDeleted: () => {}),
+    );
+
+    await tester.pumpWidget(target);
+    await tester.pumpAndSettle();
+
+    await tester.tap(find.byType(DeleteAccount));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsOneWidget);
+
+    await tester.tap(find.text('Cancel'));
+    await tester.pumpAndSettle();
+
+    expect(find.byType(AlertDialog), findsNothing);
+    verifyNever(() => client.deleteAccount());
+  });
+}

--- a/packages/apptive_grid_user_management/test/src/translation/localization_test.dart
+++ b/packages/apptive_grid_user_management/test/src/translation/localization_test.dart
@@ -498,4 +498,13 @@ class CustomTestTranslation extends ApptiveGridUserManagementTranslation {
 
   @override
   String get actionJoinGroup => 'actionJoinGroup';
+
+  @override
+  String get actionDelete => 'actionDelete';
+
+  @override
+  String get deleteAccount => 'deleteAccount';
+
+  @override
+  String get deleteAccountConfirmation => 'deleteAccountConfirmation';
 }


### PR DESCRIPTION
- Adding Delete Account Widgets to User Managment
- Add Call do delete Account to User Management
- Expose `defaultHeaders` and `authenticator` in `ApptiveGridClient` to use in User Management