### PR TITLE
Ac 2009 cleanup hashcode and to string

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -29,7 +29,7 @@ jobs:
         uses: VeryGoodOpenSource/very_good_coverage@v1
         with:
           path: ./packages/apptive_grid_core/coverage/lcov.info
-          min_coverage: 99.59
+          min_coverage: 99.6
       - name: Form Coverage
         uses: VeryGoodOpenSource/very_good_coverage@v1
         with:

--- a/packages/apptive_grid_core/lib/apptive_grid_options.dart
+++ b/packages/apptive_grid_core/lib/apptive_grid_options.dart
@@ -67,7 +67,7 @@ class ApptiveGridOptions {
 
   @override
   String toString() {
-    return 'ApptiveGridOptions(environment: $environment, authenticationOptions: $authenticationOptions, cache: $cache, attachmentConfigurations: $attachmentConfigurations)';
+    return 'ApptiveGridOptions(environment: $environment, authenticationOptions: $authenticationOptions, cache: $cache, attachmentConfigurations: $attachmentConfigurations, formWidgetConfigurations: $formWidgetConfigurations)';
   }
 
   @override
@@ -76,11 +76,18 @@ class ApptiveGridOptions {
         other.environment == environment &&
         other.authenticationOptions == authenticationOptions &&
         other.cache == other.cache &&
-        mapEquals(other.attachmentConfigurations, attachmentConfigurations);
+        mapEquals(other.attachmentConfigurations, attachmentConfigurations) &&
+        listEquals(other.formWidgetConfigurations, formWidgetConfigurations);
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(
+        environment,
+        authenticationOptions,
+        cache,
+        attachmentConfigurations,
+        formWidgetConfigurations,
+      );
 }
 
 /// A Configuration for FormWidgets needed for certain [DataType]s with [apptive_grid_form](https://pub.dev/packages/apptive_grid_form)

--- a/packages/apptive_grid_core/lib/model/attachment/attachment.dart
+++ b/packages/apptive_grid_core/lib/model/attachment/attachment.dart
@@ -63,5 +63,6 @@ class Attachment {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode =>
+      Object.hash(name, url, type, smallThumbnail, largeThumbnail);
 }

--- a/packages/apptive_grid_core/lib/model/attachment/attachment_action.dart
+++ b/packages/apptive_grid_core/lib/model/attachment/attachment_action.dart
@@ -79,7 +79,7 @@ class AddAttachmentAction extends AttachmentAction {
 
   @override
   String toString() {
-    return 'AddAttachmentAction(path: $path, byteData(byteSize): ${byteData?.lengthInBytes}, attachment: $attachment)';
+    return 'AddAttachmentAction(attachment: $attachment, path: $path, byteData(byteSize): ${byteData?.lengthInBytes})';
   }
 
   @override
@@ -91,7 +91,7 @@ class AddAttachmentAction extends AttachmentAction {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(attachment, path, byteData);
 }
 
 /// Implementation of an [AttachmentAction] for [AttachmentActionType.delete]
@@ -117,7 +117,7 @@ class DeleteAttachmentAction extends AttachmentAction {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => attachment.hashCode;
 }
 
 /// Implementation of an [AttachmentAction] for [AttachmentActionType.delete]
@@ -149,5 +149,5 @@ class RenameAttachmentAction extends AttachmentAction {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(attachment, newName);
 }

--- a/packages/apptive_grid_core/lib/model/attachment/attachment_configuration.dart
+++ b/packages/apptive_grid_core/lib/model/attachment/attachment_configuration.dart
@@ -45,7 +45,11 @@ class AttachmentConfiguration {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(
+        signedUrlApiEndpoint,
+        attachmentApiEndpoint,
+        signedUrlFormApiEndpoint,
+      );
 }
 
 /// Converts a [configString] to an actual map of [ApptiveGridEnvironment] and [ApptiveGridConfiguration]

--- a/packages/apptive_grid_core/lib/model/created_by/created_by.dart
+++ b/packages/apptive_grid_core/lib/model/created_by/created_by.dart
@@ -49,7 +49,7 @@ class CreatedBy {
 
   @override
   String toString() {
-    return 'UserReference(displayValue: $displayValue, id: $id, name: $name, type: ${type.name})';
+    return 'CreatedBy(displayValue: $displayValue, id: $id, name: $name, type: ${type.name})';
   }
 
   @override
@@ -62,7 +62,7 @@ class CreatedBy {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(displayValue, id, name, type);
 }
 
 /// Different types that have created a specific entity

--- a/packages/apptive_grid_core/lib/model/data_entity.dart
+++ b/packages/apptive_grid_core/lib/model/data_entity.dart
@@ -27,7 +27,7 @@ abstract class DataEntity<T, S> with FilterableMixin {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => value?.hashCode ?? null.hashCode;
 
   @override
   dynamic get filterValue => schemaValue;
@@ -189,7 +189,7 @@ class EnumDataEntity extends DataEntity<String, String> {
 
   @override
   String toString() {
-    return '$runtimeType(value: $value, values: $options)}';
+    return 'EnumDataEntity(value: $value, options: $options)';
   }
 
   @override
@@ -200,7 +200,7 @@ class EnumDataEntity extends DataEntity<String, String> {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(value, options);
 }
 
 /// [DataEntity] representing an enum like Object
@@ -229,7 +229,7 @@ class EnumCollectionDataEntity extends DataEntity<Set<String>, List<String>>
 
   @override
   String toString() {
-    return '$runtimeType(value: $value, values: $options)}';
+    return 'EnumCollectionDataEntity(value: $value, options: $options)';
   }
 
   @override
@@ -240,7 +240,7 @@ class EnumCollectionDataEntity extends DataEntity<Set<String>, List<String>>
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(value, options);
 }
 
 /// [DataEntity] representing an Object CrossReferencing to a different Grid
@@ -293,7 +293,7 @@ class CrossReferenceDataEntity extends DataEntity<String, dynamic> {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(value, entityUri, gridUri);
 }
 
 /// [DataEntity] representing an array of Attachments
@@ -335,7 +335,7 @@ class AttachmentDataEntity extends DataEntity<List<Attachment>, dynamic>
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => value?.hashCode ?? null.hashCode;
 }
 
 /// [DataEntity] representing [Geolocation]s
@@ -414,7 +414,7 @@ class MultiCrossReferenceDataEntity
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(value, gridUri);
 }
 
 /// [DataEntity] representing [CreatedBy]s
@@ -470,7 +470,7 @@ class CurrencyDataEntity extends DataEntity<double, double> {
   final String currency;
 
   @override
-  String toString() => 'CurrencyDataEntity($value, currency: $currency)';
+  String toString() => 'CurrencyDataEntity($value $currency)';
 
   @override
   bool operator ==(Object other) {
@@ -480,7 +480,7 @@ class CurrencyDataEntity extends DataEntity<double, double> {
   }
 
   @override
-  int get hashCode => super.hashCode + currency.hashCode;
+  int get hashCode => Object.hash(value, currency);
 }
 
 /// [DataEntity] to representing a [Uri]

--- a/packages/apptive_grid_core/lib/model/entity/entities_response.dart
+++ b/packages/apptive_grid_core/lib/model/entity/entities_response.dart
@@ -17,7 +17,7 @@ class EntitiesResponse<T> {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => items.hashCode;
 
   /// Copies this Object with provided arguments
   EntitiesResponse copyWith({List<T>? items}) {

--- a/packages/apptive_grid_core/lib/model/form/component/form_component.dart
+++ b/packages/apptive_grid_core/lib/model/form/component/form_component.dart
@@ -69,12 +69,7 @@ class FormComponent<T extends DataEntity> {
   }
 
   @override
-  int get hashCode =>
-      field.hashCode +
-      property.hashCode +
-      data.hashCode +
-      options.hashCode +
-      required.hashCode;
+  int get hashCode => Object.hash(field, property, data, options, required);
 
   /// Mapping to a concrete implementation based on [json] and [schema]
   ///

--- a/packages/apptive_grid_core/lib/model/form/component/options.dart
+++ b/packages/apptive_grid_core/lib/model/form/component/options.dart
@@ -60,5 +60,5 @@ class FormComponentOptions {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(multi, placeholder, description, label);
 }

--- a/packages/apptive_grid_core/lib/model/form/form_actions.dart
+++ b/packages/apptive_grid_core/lib/model/form/form_actions.dart
@@ -38,5 +38,5 @@ class ActionItem {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(link, data);
 }

--- a/packages/apptive_grid_core/lib/model/form/form_data.dart
+++ b/packages/apptive_grid_core/lib/model/form/form_data.dart
@@ -119,5 +119,14 @@ class FormData {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(
+        id,
+        name,
+        description,
+        title,
+        fields,
+        components,
+        attachmentActions,
+        links,
+      );
 }

--- a/packages/apptive_grid_core/lib/model/geolocation/geolocation.dart
+++ b/packages/apptive_grid_core/lib/model/geolocation/geolocation.dart
@@ -38,5 +38,5 @@ class Geolocation {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(latitude, longitude);
 }

--- a/packages/apptive_grid_core/lib/model/grid/grid.dart
+++ b/packages/apptive_grid_core/lib/model/grid/grid.dart
@@ -106,7 +106,7 @@ class Grid {
 
   @override
   String toString() {
-    return 'Grid(id: $id, name: $name, key: $key, fields: $fields, hiddenFields: $hiddenFields, rows: $rows, filter: $filter, sorting: $sorting, links: $links)';
+    return 'Grid(id: $id, name: $name, key: $key, fields: $fields, hiddenFields: $hiddenFields, rows: $rows, filter: $filter, sorting: $sorting, links: $links, embeddedForms: $embeddedForms)';
   }
 
   @override
@@ -125,5 +125,16 @@ class Grid {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(
+        id,
+        name,
+        key,
+        fields,
+        hiddenFields,
+        rows,
+        filter,
+        sorting,
+        links,
+        embeddedForms,
+      );
 }

--- a/packages/apptive_grid_core/lib/model/grid/grid_entry.dart
+++ b/packages/apptive_grid_core/lib/model/grid/grid_entry.dart
@@ -34,5 +34,5 @@ class GridEntry {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(field, data);
 }

--- a/packages/apptive_grid_core/lib/model/grid/grid_field.dart
+++ b/packages/apptive_grid_core/lib/model/grid/grid_field.dart
@@ -87,7 +87,7 @@ class GridField {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(id, name, key, type, links);
 }
 
 /// A [GridField] for [DataType.currency]

--- a/packages/apptive_grid_core/lib/model/grid/grid_row.dart
+++ b/packages/apptive_grid_core/lib/model/grid/grid_row.dart
@@ -62,5 +62,5 @@ class GridRow {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(id, entries, links);
 }

--- a/packages/apptive_grid_core/lib/model/link/apptive_link.dart
+++ b/packages/apptive_grid_core/lib/model/link/apptive_link.dart
@@ -39,7 +39,7 @@ class ApptiveLink {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(uri, method);
 }
 
 /// A Map of Links

--- a/packages/apptive_grid_core/lib/model/space/space.dart
+++ b/packages/apptive_grid_core/lib/model/space/space.dart
@@ -74,7 +74,7 @@ class Space {
 
   @override
   String toString() {
-    return 'Space(name: $name, id: $id, key: $key, category: $category, links: $links)';
+    return 'Space(name: $name, id: $id, key: $key, category: $category, links: $links, embeddedGrids: $embeddedGrids)';
   }
 
   @override
@@ -89,7 +89,14 @@ class Space {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(
+        id,
+        name,
+        key,
+        category,
+        links,
+        embeddedGrids,
+      );
 }
 
 /// A [Space] shared with a [User]
@@ -135,7 +142,7 @@ class SharedSpace extends Space {
 
   @override
   String toString() {
-    return 'SharedSpace(name: $name, id: $id, key: $key, category: $category, realSpace: ${realSpace.toString()}, links: $links)';
+    return 'SharedSpace(name: $name, id: $id, key: $key, category: $category, realSpace: ${realSpace.toString()}, links: $links, embeddedGrids: $embeddedGrids)';
   }
 
   @override
@@ -151,5 +158,13 @@ class SharedSpace extends Space {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(
+        id,
+        name,
+        realSpace,
+        key,
+        category,
+        links,
+        embeddedGrids,
+      );
 }

--- a/packages/apptive_grid_core/lib/model/user/user.dart
+++ b/packages/apptive_grid_core/lib/model/user/user.dart
@@ -67,7 +67,7 @@ class User {
 
   @override
   String toString() {
-    return 'User(email: $email, lastName: $lastName, firstName: $firstName, id: $id, links: $links)';
+    return 'User($firstName $lastName, email: $email, id: $id, links: $links, embeddedSpaces: $embeddedSpaces)';
   }
 
   @override
@@ -82,5 +82,12 @@ class User {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(
+        id,
+        email,
+        lastName,
+        firstName,
+        links,
+        embeddedSpaces,
+      );
 }

--- a/packages/apptive_grid_core/lib/network/authentication/apptive_grid_authentication_options.dart
+++ b/packages/apptive_grid_core/lib/network/authentication/apptive_grid_authentication_options.dart
@@ -31,7 +31,7 @@ class ApptiveGridAuthenticationOptions {
 
   @override
   String toString() {
-    return 'ApptiveGridAuthenticationOptions(autoAuthenticate: $autoAuthenticate, redirectScheme: $redirectScheme, apiKey: $apiKey, authenticationStorage: $persistCredentials)';
+    return 'ApptiveGridAuthenticationOptions(autoAuthenticate: $autoAuthenticate, redirectScheme: $redirectScheme, apiKey: $apiKey, persistCredentials: $persistCredentials)';
   }
 
   @override
@@ -44,7 +44,12 @@ class ApptiveGridAuthenticationOptions {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(
+        autoAuthenticate,
+        redirectScheme,
+        apiKey,
+        persistCredentials,
+      );
 }
 
 /// Model to Handle Api Key Authentication
@@ -76,5 +81,5 @@ class ApptiveGridApiKey {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(authKey, password);
 }

--- a/packages/apptive_grid_core/lib/network/filter/apptive_grid_filter.dart
+++ b/packages/apptive_grid_core/lib/network/filter/apptive_grid_filter.dart
@@ -31,7 +31,7 @@ abstract class ApptiveGridFilter {
 
   @override
   String toString() {
-    return toJson().toString();
+    return '$runtimeType(${toJson().toString()})';
   }
 }
 
@@ -80,7 +80,7 @@ abstract class _FilterComposition extends ApptiveGridFilter {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(operator, conditions);
 }
 
 /// Creates a Filter that checks that all [conditions] are true
@@ -116,5 +116,5 @@ class NotFilter extends ApptiveGridFilter {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => filter.hashCode;
 }

--- a/packages/apptive_grid_core/lib/network/filter/field_filter.dart
+++ b/packages/apptive_grid_core/lib/network/filter/field_filter.dart
@@ -49,7 +49,7 @@ abstract class _FieldFilter extends ApptiveGridFilter {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(operator, fieldId, value);
 }
 
 /// Filter to check for a Substring

--- a/packages/apptive_grid_core/lib/network/filter/filter_expressions.dart
+++ b/packages/apptive_grid_core/lib/network/filter/filter_expressions.dart
@@ -14,7 +14,7 @@ abstract class _FilterExpression with FilterableMixin {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => expression.hashCode;
 }
 
 /// Filter Columns with Type [DataType.date] to today.

--- a/packages/apptive_grid_core/lib/network/sorting/apptive_grid_sorting.dart
+++ b/packages/apptive_grid_core/lib/network/sorting/apptive_grid_sorting.dart
@@ -38,7 +38,7 @@ class ApptiveGridSorting {
 
   @override
   String toString() {
-    return toRequestObject().toString();
+    return '$runtimeType(${toRequestObject().toString()})';
   }
 
   @override
@@ -49,7 +49,7 @@ class ApptiveGridSorting {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(fieldId, order);
 
   /// Creates a new Version of [ApptiveGridSorting] changing the values of this with [fieldId] and [order] if they are not null
   ApptiveGridSorting copyWith({String? fieldId, SortOrder? order}) {
@@ -98,7 +98,7 @@ class DistanceApptiveGridSorting extends ApptiveGridSorting {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(fieldId, order, location);
 
   @override
   DistanceApptiveGridSorting copyWith({

--- a/packages/apptive_grid_core/test/apptive_grid_authentication_options_test.dart
+++ b/packages/apptive_grid_core/test/apptive_grid_authentication_options_test.dart
@@ -64,8 +64,10 @@ void main() {
     test('toString()', () {
       const key = ApptiveGridApiKey(authKey: 'authKey', password: 'password');
 
-      expect(key.toString(),
-          equals('ApptiveGridApiKey(authKey: authKey, password: password)'));
+      expect(
+        key.toString(),
+        equals('ApptiveGridApiKey(authKey: authKey, password: password)'),
+      );
     });
   });
 }

--- a/packages/apptive_grid_core/test/apptive_grid_authentication_options_test.dart
+++ b/packages/apptive_grid_core/test/apptive_grid_authentication_options_test.dart
@@ -43,7 +43,6 @@ void main() {
             ApptiveGridApiKey(authKey: 'authKey', password: 'password');
 
         expect(keyA, equals(keyB));
-        expect(keyA.hashCode, equals(keyB.hashCode));
       });
 
       test('Objects are not equal', () {
@@ -53,8 +52,20 @@ void main() {
             ApptiveGridApiKey(authKey: 'authKey', password: 'passwortWithT');
 
         expect(keyA, isNot(keyB));
-        expect(keyA.hashCode, isNot(keyB.hashCode));
       });
+    });
+
+    test('Hashcode', () {
+      const key = ApptiveGridApiKey(authKey: 'authKey', password: 'password');
+
+      expect(key.hashCode, equals(Object.hash('authKey', 'password')));
+    });
+
+    test('toString()', () {
+      const key = ApptiveGridApiKey(authKey: 'authKey', password: 'password');
+
+      expect(key.toString(),
+          equals('ApptiveGridApiKey(authKey: authKey, password: password)'));
     });
   });
 }

--- a/packages/apptive_grid_core/test/apptive_grid_options_test.dart
+++ b/packages/apptive_grid_core/test/apptive_grid_options_test.dart
@@ -60,7 +60,6 @@ void main() {
           ApptiveGridOptions(environment: ApptiveGridEnvironment.beta);
 
       expect(optionsA, equals(optionsB));
-      expect(optionsA.hashCode, equals(optionsB.hashCode));
     });
 
     test('Objects are not equal', () {
@@ -74,7 +73,42 @@ void main() {
       );
 
       expect(optionsA, isNot(optionsB));
-      expect(optionsA.hashCode, isNot(optionsB.hashCode));
     });
+  });
+
+  test('Hashcode', () {
+    const options = ApptiveGridOptions(
+      environment: ApptiveGridEnvironment.alpha,
+      authenticationOptions:
+          ApptiveGridAuthenticationOptions(autoAuthenticate: true),
+    );
+
+    expect(
+      options.hashCode,
+      equals(
+        Object.hash(
+          options.environment,
+          options.authenticationOptions,
+          options.cache,
+          options.attachmentConfigurations,
+          options.formWidgetConfigurations,
+        ),
+      ),
+    );
+  });
+
+  test('toString()', () {
+    const options = ApptiveGridOptions(
+      environment: ApptiveGridEnvironment.alpha,
+      authenticationOptions:
+          ApptiveGridAuthenticationOptions(autoAuthenticate: true),
+    );
+
+    expect(
+      options.toString(),
+      equals(
+        'ApptiveGridOptions(environment: ApptiveGridEnvironment.alpha, authenticationOptions: ApptiveGridAuthenticationOptions(autoAuthenticate: true, redirectScheme: null, apiKey: null, persistCredentials: false), cache: null, attachmentConfigurations: {}, formWidgetConfigurations: [])',
+      ),
+    );
   });
 }

--- a/packages/apptive_grid_core/test/apptive_link_test.dart
+++ b/packages/apptive_grid_core/test/apptive_link_test.dart
@@ -8,7 +8,6 @@ void main() {
       final b = ApptiveLink(uri: Uri.parse('uri.toParse'), method: 'get');
 
       expect(a, equals(b));
-      expect(a.hashCode, equals(b.hashCode));
     });
 
     test('In Equality', () {

--- a/packages/apptive_grid_core/test/assignee_test.dart
+++ b/packages/apptive_grid_core/test/assignee_test.dart
@@ -210,7 +210,6 @@ void main() {
       expect(a, equals(b));
       expect(a, isNot(c));
 
-      expect(a.hashCode, equals(b.hashCode));
       expect(a.hashCode, isNot(c.hashCode));
     });
   });

--- a/packages/apptive_grid_core/test/attachment_action_test.dart
+++ b/packages/apptive_grid_core/test/attachment_action_test.dart
@@ -51,13 +51,18 @@ void main() {
 
   group('Hashcode', () {
     final attachment = Attachment(
-        name: 'name', url: Uri(path: 'attachment'), type: 'image/png');
+      name: 'name',
+      url: Uri(path: 'attachment'),
+      type: 'image/png',
+    );
     test('AddAttachmentAction', () {
       final action =
           AddAttachmentAction(attachment: attachment, path: '/path/toFile');
 
-      expect(action.hashCode,
-          equals(Object.hash(attachment, action.path, action.byteData)));
+      expect(
+        action.hashCode,
+        equals(Object.hash(attachment, action.path, action.byteData)),
+      );
     });
 
     test('DeleteAttachmentAction', () {
@@ -67,7 +72,9 @@ void main() {
     });
     test('RenameAttachmentAction', () {
       final action = RenameAttachmentAction(
-          attachment: attachment, newName: '/path/toFile');
+        attachment: attachment,
+        newName: '/path/toFile',
+      );
 
       expect(action.hashCode, equals(Object.hash(attachment, action.newName)));
     });
@@ -75,31 +82,42 @@ void main() {
 
   group('toString()', () {
     final attachment = Attachment(
-        name: 'name', url: Uri(path: 'attachment'), type: 'image/png');
+      name: 'name',
+      url: Uri(path: 'attachment'),
+      type: 'image/png',
+    );
     test('AddAttachmentAction', () {
       final action =
           AddAttachmentAction(attachment: attachment, path: '/path/toFile');
 
       expect(
-          action.toString(),
-          equals(
-              'AddAttachmentAction(attachment: $attachment, path: /path/toFile, byteData(byteSize): null)'));
+        action.toString(),
+        equals(
+          'AddAttachmentAction(attachment: $attachment, path: /path/toFile, byteData(byteSize): null)',
+        ),
+      );
     });
 
     test('DeleteAttachmentAction', () {
       final action = DeleteAttachmentAction(attachment: attachment);
 
-      expect(action.toString(),
-          equals('DeleteAttachmentAction(attachment: $attachment)'));
+      expect(
+        action.toString(),
+        equals('DeleteAttachmentAction(attachment: $attachment)'),
+      );
     });
     test('RenameAttachmentAction', () {
       final action = RenameAttachmentAction(
-          attachment: attachment, newName: '/path/toFile');
+        attachment: attachment,
+        newName: '/path/toFile',
+      );
 
       expect(
-          action.toString(),
-          equals(
-              'RenameAttachmentAction(newName: /path/toFile, attachment: $attachment)'));
+        action.toString(),
+        equals(
+          'RenameAttachmentAction(newName: /path/toFile, attachment: $attachment)',
+        ),
+      );
     });
   });
 }

--- a/packages/apptive_grid_core/test/attachment_action_test.dart
+++ b/packages/apptive_grid_core/test/attachment_action_test.dart
@@ -19,7 +19,6 @@ void main() {
           AttachmentAction.fromJson(jsonDecode(jsonEncode(action.toJson())));
 
       expect(action, equals(restored));
-      expect(action.hashCode, equals(restored.hashCode));
     });
 
     test('Delete Action parses and restores', () {
@@ -28,7 +27,6 @@ void main() {
           AttachmentAction.fromJson(jsonDecode(jsonEncode(action.toJson())));
 
       expect(action, equals(restored));
-      expect(action.hashCode, equals(restored.hashCode));
     });
 
     test('Rename Action parses and restores', () {
@@ -38,7 +36,6 @@ void main() {
           AttachmentAction.fromJson(jsonDecode(jsonEncode(action.toJson())));
 
       expect(action, equals(restored));
-      expect(action.hashCode, equals(restored.hashCode));
     });
 
     test('Unknown ActionType throws Error', () {
@@ -49,6 +46,60 @@ void main() {
         }),
         throwsA(isInstanceOf<ArgumentError>()),
       );
+    });
+  });
+
+  group('Hashcode', () {
+    final attachment = Attachment(
+        name: 'name', url: Uri(path: 'attachment'), type: 'image/png');
+    test('AddAttachmentAction', () {
+      final action =
+          AddAttachmentAction(attachment: attachment, path: '/path/toFile');
+
+      expect(action.hashCode,
+          equals(Object.hash(attachment, action.path, action.byteData)));
+    });
+
+    test('DeleteAttachmentAction', () {
+      final action = DeleteAttachmentAction(attachment: attachment);
+
+      expect(action.hashCode, equals(attachment.hashCode));
+    });
+    test('RenameAttachmentAction', () {
+      final action = RenameAttachmentAction(
+          attachment: attachment, newName: '/path/toFile');
+
+      expect(action.hashCode, equals(Object.hash(attachment, action.newName)));
+    });
+  });
+
+  group('toString()', () {
+    final attachment = Attachment(
+        name: 'name', url: Uri(path: 'attachment'), type: 'image/png');
+    test('AddAttachmentAction', () {
+      final action =
+          AddAttachmentAction(attachment: attachment, path: '/path/toFile');
+
+      expect(
+          action.toString(),
+          equals(
+              'AddAttachmentAction(attachment: $attachment, path: /path/toFile, byteData(byteSize): null)'));
+    });
+
+    test('DeleteAttachmentAction', () {
+      final action = DeleteAttachmentAction(attachment: attachment);
+
+      expect(action.toString(),
+          equals('DeleteAttachmentAction(attachment: $attachment)'));
+    });
+    test('RenameAttachmentAction', () {
+      final action = RenameAttachmentAction(
+          attachment: attachment, newName: '/path/toFile');
+
+      expect(
+          action.toString(),
+          equals(
+              'RenameAttachmentAction(newName: /path/toFile, attachment: $attachment)'));
     });
   });
 }

--- a/packages/apptive_grid_core/test/attachment_configuration_test.dart
+++ b/packages/apptive_grid_core/test/attachment_configuration_test.dart
@@ -24,11 +24,15 @@ void main() {
       signedUrlFormApiEndpoint: 'https://attachmentApiEndpoint.com',
     );
     expect(
-        configuration.hashCode,
-        equals(Object.hash(
-            configuration.signedUrlApiEndpoint,
-            configuration.attachmentApiEndpoint,
-            configuration.signedUrlFormApiEndpoint)));
+      configuration.hashCode,
+      equals(
+        Object.hash(
+          configuration.signedUrlApiEndpoint,
+          configuration.attachmentApiEndpoint,
+          configuration.signedUrlFormApiEndpoint,
+        ),
+      ),
+    );
   });
 
   test('toString()', () {
@@ -38,9 +42,11 @@ void main() {
       signedUrlFormApiEndpoint: 'https://attachmentApiEndpoint.com',
     );
     expect(
-        configuration.toString(),
-        equals(
-            'AttachmentConfiguration(signedUrlApiEndpoint: https://signedUrlEndpoint.com, signedUrlFormApiEndpoint: https://attachmentApiEndpoint.com, attachmentApiEndpoint: https://attachmentApiEndpoint.com)'));
+      configuration.toString(),
+      equals(
+        'AttachmentConfiguration(signedUrlApiEndpoint: https://signedUrlEndpoint.com, signedUrlFormApiEndpoint: https://attachmentApiEndpoint.com, attachmentApiEndpoint: https://attachmentApiEndpoint.com)',
+      ),
+    );
   });
 
   group('From Configuration String', () {

--- a/packages/apptive_grid_core/test/attachment_configuration_test.dart
+++ b/packages/apptive_grid_core/test/attachment_configuration_test.dart
@@ -14,8 +14,33 @@ void main() {
       });
 
       expect(direct, equals(fromJson));
-      expect(direct.hashCode, equals(fromJson.hashCode));
     });
+  });
+
+  test('Hashcode', () {
+    const configuration = AttachmentConfiguration(
+      signedUrlApiEndpoint: 'https://signedUrlEndpoint.com',
+      attachmentApiEndpoint: 'https://attachmentApiEndpoint.com',
+      signedUrlFormApiEndpoint: 'https://attachmentApiEndpoint.com',
+    );
+    expect(
+        configuration.hashCode,
+        equals(Object.hash(
+            configuration.signedUrlApiEndpoint,
+            configuration.attachmentApiEndpoint,
+            configuration.signedUrlFormApiEndpoint)));
+  });
+
+  test('toString()', () {
+    const configuration = AttachmentConfiguration(
+      signedUrlApiEndpoint: 'https://signedUrlEndpoint.com',
+      attachmentApiEndpoint: 'https://attachmentApiEndpoint.com',
+      signedUrlFormApiEndpoint: 'https://attachmentApiEndpoint.com',
+    );
+    expect(
+        configuration.toString(),
+        equals(
+            'AttachmentConfiguration(signedUrlApiEndpoint: https://signedUrlEndpoint.com, signedUrlFormApiEndpoint: https://attachmentApiEndpoint.com, attachmentApiEndpoint: https://attachmentApiEndpoint.com)'));
   });
 
   group('From Configuration String', () {

--- a/packages/apptive_grid_core/test/attachment_test.dart
+++ b/packages/apptive_grid_core/test/attachment_test.dart
@@ -397,7 +397,37 @@ void main() {
       );
 
       expect(fromJson, equals(direct));
-      expect(fromJson.hashCode, equals(direct.hashCode));
+    });
+
+    test('Hashcode', () {
+      const field =
+          GridField(id: 'id', name: 'property', type: DataType.attachment);
+
+      final directEntity = AttachmentDataEntity.fromJson([
+        {
+          'smallThumbnail': null,
+          'url': 'https://attachment.com/id',
+          'largeThumbnail': null,
+          'name': 'anakin_cyrille.PNG',
+          'type': 'image/png'
+        }
+      ]);
+      final component = FormComponent<AttachmentDataEntity>(
+        property: 'New field',
+        data: directEntity,
+        field: field,
+      );
+
+      expect(
+        component.hashCode,
+        Object.hash(
+          component.field,
+          component.property,
+          component.data,
+          component.options,
+          component.required,
+        ),
+      );
     });
   });
 
@@ -449,7 +479,6 @@ void main() {
       );
 
       expect(fromJson, equals(direct));
-      expect(fromJson.hashCode, equals(direct.hashCode));
     });
   });
 }

--- a/packages/apptive_grid_core/test/created_by_test.dart
+++ b/packages/apptive_grid_core/test/created_by_test.dart
@@ -185,7 +185,7 @@ void main() {
       expect(grid.rows!.length, equals(4));
     });
 
-    group('UserReference Type', () {
+    group('CreatedBy Type', () {
       final grid = Grid.fromJson(rawResponse);
 
       test('Null', () {
@@ -268,12 +268,11 @@ void main() {
       expect(a, equals(b));
       expect(a, isNot(c));
 
-      expect(a.hashCode, equals(b.hashCode));
       expect(a.hashCode, isNot(c.hashCode));
     });
   });
 
-  group('UserReference', () {
+  group('CreatedBy', () {
     test('Equality', () {
       const one = CreatedBy(
         id: 'userId',
@@ -293,6 +292,20 @@ void main() {
 
       expect(one, equals(two));
       expect(one.hashCode, equals(two.hashCode));
+    });
+
+    test('toString()', () {
+      const createdBy = CreatedBy(
+        id: 'userId',
+        type: CreatedByType.user,
+        displayValue: 'Jane Doe',
+        name: 'jane.doe@2denker.de',
+      );
+
+      expect(
+          createdBy.toString(),
+          equals(
+              'CreatedBy(displayValue: Jane Doe, id: userId, name: jane.doe@2denker.de, type: user)'));
     });
   });
 }

--- a/packages/apptive_grid_core/test/created_by_test.dart
+++ b/packages/apptive_grid_core/test/created_by_test.dart
@@ -303,9 +303,11 @@ void main() {
       );
 
       expect(
-          createdBy.toString(),
-          equals(
-              'CreatedBy(displayValue: Jane Doe, id: userId, name: jane.doe@2denker.de, type: user)'));
+        createdBy.toString(),
+        equals(
+          'CreatedBy(displayValue: Jane Doe, id: userId, name: jane.doe@2denker.de, type: user)',
+        ),
+      );
     });
   });
 }

--- a/packages/apptive_grid_core/test/cross_reference_test.dart
+++ b/packages/apptive_grid_core/test/cross_reference_test.dart
@@ -189,7 +189,6 @@ void main() {
         expect(a, equals(b));
         expect(a, isNot(c));
 
-        expect(a.hashCode, equals(b.hashCode));
         expect(a.hashCode, isNot(c.hashCode));
       });
     });
@@ -235,6 +234,19 @@ void main() {
         );
 
         expect(entity.schemaValue, isNull);
+      });
+
+      test('toString() produces correct output', () {
+        final entity = CrossReferenceDataEntity(
+          gridUri: Uri.parse('uri'),
+          value: null,
+          entityUri: Uri.parse('entityUri'),
+        );
+
+        expect(
+          entity.toString(),
+          'CrossReferenceDataEntity(displayValue: null, entityUri: entityUri, gridUri: uri)',
+        );
       });
     });
   });
@@ -331,7 +343,29 @@ void main() {
       );
 
       expect(fromJson, equals(direct));
-      expect(fromJson.hashCode, equals(direct.hashCode));
+    });
+
+    test('Hashcode is Correct', () {
+      final component = FormComponent<CrossReferenceDataEntity>(
+        property: 'name',
+        data: CrossReferenceDataEntity(gridUri: Uri(path: '/grid')),
+        field: const GridField(
+          id: '3ftoqhqbct15h5o730uknpvp5',
+          name: 'name',
+          type: DataType.crossReference,
+        ),
+      );
+
+      expect(
+        component.hashCode,
+        Object.hash(
+          component.field,
+          component.property,
+          component.data,
+          component.options,
+          component.required,
+        ),
+      );
     });
   });
 }

--- a/packages/apptive_grid_core/test/currency_test.dart
+++ b/packages/apptive_grid_core/test/currency_test.dart
@@ -171,6 +171,33 @@ void main() {
         'CurrencyGridField(id: id, name: Currency, key: key, currency: USD)',
       );
     });
+
+    test('Hashcode', () {
+      const field = CurrencyGridField(
+        id: 'id',
+        name: 'Currency',
+        key: 'key',
+        links: {},
+        currency: 'USD',
+      );
+
+      expect(
+        field.hashCode,
+        equals(
+          Object.hash(
+            GridField(
+              id: field.id,
+              name: field.name,
+              type: field.type,
+              key: field.key,
+              links: field.links,
+              schema: field.schema,
+            ),
+            'USD',
+          ),
+        ),
+      );
+    });
   });
 
   group('DataEntity', () {
@@ -180,9 +207,18 @@ void main() {
       final c = CurrencyDataEntity(currency: 'EUR', value: 12345.12);
       expect(a, equals(b));
       expect(a, isNot(c));
+    });
 
-      expect(a.hashCode, equals(b.hashCode));
-      expect(a.hashCode, isNot(c.hashCode));
+    test('Hashcode', () {
+      final currency = CurrencyDataEntity(currency: 'USD', value: 12345.12);
+
+      expect(currency.hashCode, Object.hash(12345.12, 'USD'));
+    });
+
+    test('toString()', () {
+      final currency = CurrencyDataEntity(currency: 'USD', value: 12345.12);
+
+      expect(currency.toString(), equals('CurrencyDataEntity(12345.12 USD)'));
     });
   });
 
@@ -308,7 +344,29 @@ void main() {
       );
 
       expect(fromJson.cast<CurrencyDataEntity>(), equals(direct));
-      expect(fromJson.hashCode, equals(direct.hashCode));
+    });
+
+    test('Hashcode', () {
+      const field =
+          GridField(id: 'id', name: 'property', type: DataType.attachment);
+
+      final directEntity = CurrencyDataEntity(currency: 'EUR', value: 12345.12);
+      final component = FormComponent<CurrencyDataEntity>(
+        property: 'New field',
+        data: directEntity,
+        field: field,
+      );
+
+      expect(
+        component.hashCode,
+        Object.hash(
+          component.field,
+          component.property,
+          component.data,
+          component.options,
+          component.required,
+        ),
+      );
     });
   });
 }

--- a/packages/apptive_grid_core/test/data_entity_test.dart
+++ b/packages/apptive_grid_core/test/data_entity_test.dart
@@ -150,8 +150,10 @@ void main() {
       final values = {'value', 'otherValue'};
       final entity = EnumDataEntity(value: value, options: values);
 
-      expect(entity.toString(),
-          equals('EnumDataEntity(value: $value, options: $values)'));
+      expect(
+        entity.toString(),
+        equals('EnumDataEntity(value: $value, options: $values)'),
+      );
     });
   });
 
@@ -222,9 +224,11 @@ void main() {
         final entity = EnumCollectionDataEntity(value: value, options: values);
 
         expect(
-            entity.toString(),
-            equals(
-                'EnumCollectionDataEntity(value: $value, options: $values)'));
+          entity.toString(),
+          equals(
+            'EnumCollectionDataEntity(value: $value, options: $values)',
+          ),
+        );
       });
     });
   });

--- a/packages/apptive_grid_core/test/data_entity_test.dart
+++ b/packages/apptive_grid_core/test/data_entity_test.dart
@@ -136,6 +136,23 @@ void main() {
       expect(entity.value, equals(null));
       expect(entity.options, equals([]));
     });
+
+    test('Hashcode', () {
+      const value = 'value';
+      final values = {'value', 'otherValue'};
+      final entity = EnumDataEntity(value: value, options: values);
+
+      expect(entity.hashCode, equals(Object.hash(value, values)));
+    });
+
+    test('toString()', () {
+      const value = 'value';
+      final values = {'value', 'otherValue'};
+      final entity = EnumDataEntity(value: value, options: values);
+
+      expect(entity.toString(),
+          equals('EnumDataEntity(value: $value, options: $values)'));
+    });
   });
 
   group('EnumCollection', () {
@@ -165,7 +182,6 @@ void main() {
             EnumCollectionDataEntity(value: {'A', 'B'}, options: {'A', 'B'});
 
         expect(a, equals(b));
-        expect(a.hashCode, equals(b.hashCode));
       });
 
       test(
@@ -177,7 +193,6 @@ void main() {
             EnumCollectionDataEntity(value: {'B', 'A'}, options: {'A', 'B'});
 
         expect(a, equals(b));
-        expect(a.hashCode, isNot(b.hashCode));
       });
 
       test('Unequals', () {
@@ -191,7 +206,25 @@ void main() {
         );
 
         expect(a, isNot(b));
-        expect(a.hashCode, isNot(b.hashCode));
+      });
+
+      test('Hashcode', () {
+        const value = {'value'};
+        final values = {'value', 'otherValue'};
+        final entity = EnumCollectionDataEntity(value: value, options: values);
+
+        expect(entity.hashCode, equals(Object.hash(value, values)));
+      });
+
+      test('toString()', () {
+        const value = {'value'};
+        final values = {'value', 'otherValue'};
+        final entity = EnumCollectionDataEntity(value: value, options: values);
+
+        expect(
+            entity.toString(),
+            equals(
+                'EnumCollectionDataEntity(value: $value, options: $values)'));
       });
     });
   });
@@ -213,19 +246,15 @@ void main() {
 
     test('equals', () {
       expect(string, equals(stringEquals));
-      expect(string.hashCode, equals(stringEquals.hashCode));
       expect(selection, equals(equalSelection));
-      expect(selection.hashCode, equals(equalSelection.hashCode));
     });
     test('not equals', () {
       expect(string, isNot(stringUnequals));
-      expect(string.hashCode, isNot(stringUnequals.hashCode));
-      expect(string.hashCode, isNot(integer.hashCode));
-      expect(string.hashCode, isNot(date.hashCode));
-      expect(string.hashCode, isNot(dateTime.hashCode));
-      expect(string.hashCode, isNot(boolean.hashCode));
+      expect(string, isNot(integer));
+      expect(string, isNot(date));
+      expect(string, isNot(dateTime));
+      expect(string, isNot(boolean));
       expect(selection, isNot(unEqualSelection));
-      expect(selection.hashCode, isNot(unEqualSelection.hashCode));
     });
   });
 
@@ -256,7 +285,6 @@ void main() {
       );
 
       expect(direct, equals(fromJson));
-      expect(direct.hashCode, equals(fromJson.hashCode));
     });
 
     test('Null json is Empty List', () {

--- a/packages/apptive_grid_core/test/decimal_test.dart
+++ b/packages/apptive_grid_core/test/decimal_test.dart
@@ -136,7 +136,6 @@ void main() {
       expect(a, equals(b));
       expect(a, isNot(c));
 
-      expect(a.hashCode, equals(b.hashCode));
       expect(a.hashCode, isNot(c.hashCode));
     });
   });
@@ -213,7 +212,29 @@ void main() {
       );
 
       expect(fromJson, equals(direct));
-      expect(fromJson.hashCode, equals(direct.hashCode));
+    });
+
+    test('Hashcode', () {
+      const field =
+          GridField(id: 'id', name: 'property', type: DataType.attachment);
+
+      final directEntity = DecimalDataEntity(47.11);
+      final component = FormComponent<DecimalDataEntity>(
+        property: 'New field',
+        data: directEntity,
+        field: field,
+      );
+
+      expect(
+        component.hashCode,
+        Object.hash(
+          component.field,
+          component.property,
+          component.data,
+          component.options,
+          component.required,
+        ),
+      );
     });
   });
 }

--- a/packages/apptive_grid_core/test/entity_response_test.dart
+++ b/packages/apptive_grid_core/test/entity_response_test.dart
@@ -22,7 +22,6 @@ void main() {
       );
 
       expect(response, equals(response2));
-      expect(response.hashCode, equals(response2.hashCode));
     });
 
     test('UnEqual', () {
@@ -44,7 +43,6 @@ void main() {
       );
 
       expect(response, isNot(response2));
-      expect(response.hashCode, isNot(response2.hashCode));
     });
   });
 
@@ -70,11 +68,37 @@ void main() {
       final response4 = response.copyWith();
 
       expect(response2, isNot(response));
-      expect(response2.hashCode, isNot(response.hashCode));
       expect(response3, equals(response));
-      expect(response3.hashCode, equals(response.hashCode));
       expect(response4, equals(response));
-      expect(response4.hashCode, equals(response.hashCode));
     });
+  });
+
+  test('Hashcode', () {
+    const response = EntitiesResponse(
+      items: [
+        {
+          '1': 'A',
+        },
+        {'1': 'B'},
+      ],
+    );
+
+    expect(response.hashCode, equals(response.items.hashCode));
+  });
+
+  test('toString()', () {
+    const response = EntitiesResponse(
+      items: [
+        {
+          '1': 'A',
+        },
+        {'1': 'B'},
+      ],
+    );
+
+    expect(
+      response.toString(),
+      equals('EntitiesResponse(items: [{1: A}, {1: B}])'),
+    );
   });
 }

--- a/packages/apptive_grid_core/test/enum_collection_test.dart
+++ b/packages/apptive_grid_core/test/enum_collection_test.dart
@@ -233,7 +233,6 @@ void main() {
       );
 
       expect(fromJson, equals(direct));
-      expect(fromJson.hashCode, equals(direct.hashCode));
     });
   });
 }

--- a/packages/apptive_grid_core/test/filter_test.dart
+++ b/packages/apptive_grid_core/test/filter_test.dart
@@ -175,7 +175,6 @@ void main() {
         );
 
         expect(a, equals(b));
-        expect(a.hashCode, equals(b.hashCode));
       });
 
       test('Different Type', () {
@@ -200,7 +199,6 @@ void main() {
         );
 
         expect(a, isNot(b));
-        expect(a.hashCode, isNot(b.hashCode));
       });
 
       test('Different Conditions', () {
@@ -225,7 +223,6 @@ void main() {
         );
 
         expect(a, isNot(b));
-        expect(a.hashCode, isNot(b.hashCode));
       });
     });
 
@@ -237,7 +234,6 @@ void main() {
             EqualsFilter(fieldId: 'fieldId', value: StringDataEntity('value'));
 
         expect(a, equals(b));
-        expect(a.hashCode, equals(b.hashCode));
       });
 
       test('Different Operator', () {
@@ -249,7 +245,6 @@ void main() {
         );
 
         expect(a, isNot(b));
-        expect(a.hashCode, isNot(b.hashCode));
       });
 
       test('Different Value', () {
@@ -259,7 +254,6 @@ void main() {
             EqualsFilter(fieldId: 'fieldId', value: StringDataEntity('value1'));
 
         expect(a, isNot(b));
-        expect(a.hashCode, isNot(b.hashCode));
       });
 
       test('Different Field', () {
@@ -269,12 +263,11 @@ void main() {
             EqualsFilter(fieldId: 'fieldId1', value: StringDataEntity('value'));
 
         expect(a, isNot(b));
-        expect(a.hashCode, isNot(b.hashCode));
       });
     });
   });
 
-  group('Combination produces correct json', () {
+  group('Combination', () {
     test('And', () async {
       expect(
         jsonEncode(
@@ -339,6 +332,25 @@ void main() {
         ),
       );
     });
+
+    test('Hashcode', () {
+      final composition = OrFilterComposition(
+        conditions: [
+          EqualsFilter(
+            fieldId: 'fieldId',
+            value: StringDataEntity('value'),
+          ),
+          AnyOfFilter(
+            fieldId: 'fieldId1',
+            value: EnumCollectionDataEntity(value: {'2', '3'}),
+          ),
+        ],
+      );
+      expect(
+        composition.hashCode,
+        equals(Object.hash(composition.operator, composition.conditions)),
+      );
+    });
   });
 
   group('Not Filter', () {
@@ -361,7 +373,7 @@ void main() {
         expect(filter1.hashCode, equals(filter2.hashCode));
       });
 
-      test('Different su filters are not equal', () async {
+      test('Different sub filters are not equal', () async {
         final filter1 = NotFilter(
           filter: EqualsFilter(
             fieldId: 'field',
@@ -396,34 +408,44 @@ void main() {
         ),
       );
     });
+  });
+  group('Filter Expression', () {
+    test('Equality', () {
+      const todayExpression = Today();
+      const loggedInExpression = LoggedInUser();
 
-    group('Filter Expression', () {
-      test('Equality', () {
-        const todayExpression = Today();
-        const loggedInExpression = LoggedInUser();
+      expect(todayExpression, isNot(equals(loggedInExpression)));
+      expect(
+        todayExpression.hashCode,
+        isNot(equals(loggedInExpression.hashCode)),
+      );
+      expect(
+        todayExpression.filterValue,
+        isNot(equals(loggedInExpression.filterValue)),
+      );
+    });
 
-        expect(todayExpression, isNot(equals(loggedInExpression)));
-        expect(
-          todayExpression.hashCode,
-          isNot(equals(loggedInExpression.hashCode)),
-        );
-        expect(
-          todayExpression.filterValue,
-          isNot(equals(loggedInExpression.filterValue)),
-        );
-      });
+    test('Today', () {
+      const todayExpression = Today();
 
-      test('Today', () {
-        const todayExpression = Today();
+      expect(todayExpression.filterValue, equals('{{ today() }}'));
+    });
 
-        expect(todayExpression.filterValue, equals('{{ today() }}'));
-      });
+    test('LoggedIn User', () {
+      const loggedInExpression = LoggedInUser();
 
-      test('LoggedIn User', () {
-        const loggedInExpression = LoggedInUser();
+      expect(loggedInExpression.filterValue, equals('{{ loggedInUser() }}'));
+    });
+  });
 
-        expect(loggedInExpression.filterValue, equals('{{ loggedInUser() }}'));
-      });
+  group('toString()', () {
+    test('Produces correct String Output', () {
+      final filter = EqualsFilter(
+        fieldId: 'field',
+        value: StringDataEntity('test'),
+      );
+
+      expect(filter.toString(), equals('EqualsFilter({field: {\$eq: test}})'));
     });
   });
 }

--- a/packages/apptive_grid_core/test/form_action_test.dart
+++ b/packages/apptive_grid_core/test/form_action_test.dart
@@ -25,7 +25,6 @@ void main() {
       expect(a, equals(b));
       expect(a, isNot(c));
 
-      expect(a.hashCode, equals(b.hashCode));
       expect(a.hashCode, isNot(c.hashCode));
     });
   });

--- a/packages/apptive_grid_core/test/form_data_test.dart
+++ b/packages/apptive_grid_core/test/form_data_test.dart
@@ -318,12 +318,10 @@ void main() {
 
     test('a == b', () {
       expect(a, equals(b));
-      expect(a.hashCode, equals(b.hashCode));
     });
 
     test('a != c', () {
       expect(a, isNot(c));
-      expect(a.hashCode, isNot(c.hashCode));
     });
   });
 

--- a/packages/apptive_grid_core/test/form_options_test.dart
+++ b/packages/apptive_grid_core/test/form_options_test.dart
@@ -18,7 +18,6 @@ void main() {
 
       test('a == b', () {
         expect(a, equals(b));
-        expect(a.hashCode, equals(b.hashCode));
       });
 
       test('a != c', () {
@@ -43,7 +42,6 @@ void main() {
 
       test('a == b', () {
         expect(a, equals(b));
-        expect(a.hashCode, equals(b.hashCode));
       });
 
       test('a != c', () {

--- a/packages/apptive_grid_core/test/geolocation_test.dart
+++ b/packages/apptive_grid_core/test/geolocation_test.dart
@@ -361,7 +361,34 @@ void main() {
       );
 
       expect(fromJson, equals(direct));
-      expect(fromJson.hashCode, equals(direct.hashCode));
+    });
+
+    test('Hashcode', () {
+      const field =
+          GridField(id: 'id', name: 'property', type: DataType.attachment);
+
+      final entity = GeolocationDataEntity(
+        const Geolocation(
+          longitude: 6.944374229580692,
+          latitude: 50.90713366617792,
+        ),
+      );
+      final component = FormComponent<GeolocationDataEntity>(
+        property: 'New field',
+        data: entity,
+        field: field,
+      );
+
+      expect(
+        component.hashCode,
+        Object.hash(
+          component.field,
+          component.property,
+          component.data,
+          component.options,
+          component.required,
+        ),
+      );
     });
   });
 
@@ -380,7 +407,27 @@ void main() {
       );
 
       expect(one, equals(two));
-      expect(one.hashCode, equals(two.hashCode));
+    });
+
+    test('Hashcode', () {
+      const location = Geolocation(
+        latitude: 47,
+        longitude: 11,
+      );
+
+      expect(location.hashCode, equals(Object.hash(47, 11)));
+    });
+
+    test('toString()', () {
+      const location = Geolocation(
+        latitude: 47,
+        longitude: 11,
+      );
+
+      expect(
+        location.toString(),
+        equals('Geolocation(latitude: 47.0, longitude: 11.0)'),
+      );
     });
   });
 }

--- a/packages/apptive_grid_core/test/grid_entry_test.dart
+++ b/packages/apptive_grid_core/test/grid_entry_test.dart
@@ -23,7 +23,6 @@ void main() {
       );
 
       expect(fromJson, equals(direct));
-      expect(fromJson.hashCode, equals(direct.hashCode));
     });
 
     test('UnEqual', () {
@@ -34,7 +33,27 @@ void main() {
       final double = GridEntry(field, StringDataEntity(value + value));
 
       expect(single, isNot(double));
-      expect(single.hashCode, isNot(double.hashCode));
     });
+  });
+
+  test('Hashcode', () {
+    const field = GridField(id: 'id', name: 'name', type: DataType.text);
+    const value = 'value';
+
+    final single = GridEntry(field, StringDataEntity(value));
+
+    expect(single.hashCode, equals(Object.hash(field, value)));
+  });
+
+  test('toString()', () {
+    const field = GridField(id: 'id', name: 'name', type: DataType.text);
+    const value = 'value';
+
+    final single = GridEntry(field, StringDataEntity(value));
+
+    expect(
+      single.toString(),
+      equals('GridEntry(field: $field, data: ${StringDataEntity(value)})'),
+    );
   });
 }

--- a/packages/apptive_grid_core/test/grid_field_test.dart
+++ b/packages/apptive_grid_core/test/grid_field_test.dart
@@ -11,7 +11,6 @@ void main() {
       const b = GridField(id: id, name: name, type: type);
 
       expect(a, equals(b));
-      expect(a.hashCode, equals(b.hashCode));
     });
 
     test('is not equal', () {
@@ -22,7 +21,6 @@ void main() {
       const b = GridField(id: name, name: id, type: type);
 
       expect(a, isNot(b));
-      expect(a.hashCode, isNot(b.hashCode));
     });
   });
 

--- a/packages/apptive_grid_core/test/grid_row_test.dart
+++ b/packages/apptive_grid_core/test/grid_row_test.dart
@@ -31,10 +31,63 @@ void main() {
         [field],
       );
 
-      expect(direct.hashCode, equals(fromJson.hashCode));
       expect(direct, equals(direct));
       expect(fromJson, equals(fromJson));
       expect(direct, equals(fromJson));
+    });
+
+    test('Hashcode', () {
+      const id = 'id';
+      const field = GridField(
+        id: 'fieldId',
+        name: 'fieldName',
+        type: DataType.text,
+        schema: {
+          {
+            'type': 'array',
+            'items': [
+              {'type': 'string'},
+            ]
+          },
+        },
+      );
+      const value = 'value';
+      final entries = <GridEntry>[
+        GridEntry(field, StringDataEntity(value)),
+      ];
+      final direct = GridRow(id: id, entries: entries, links: {});
+
+      expect(
+        direct.hashCode,
+        equals(Object.hash(direct.id, direct.entries, direct.links)),
+      );
+    });
+
+    test('toString()', () {
+      const id = 'id';
+      const field = GridField(
+        id: 'fieldId',
+        name: 'fieldName',
+        type: DataType.text,
+        schema: {
+          {
+            'type': 'array',
+            'items': [
+              {'type': 'string'},
+            ]
+          },
+        },
+      );
+      const value = 'value';
+      final entries = <GridEntry>[
+        GridEntry(field, StringDataEntity(value)),
+      ];
+      final direct = GridRow(id: id, entries: entries, links: {});
+
+      expect(
+        direct.toString(),
+        equals('GridRow(id: $id, entries: $entries, links: {})'),
+      );
     });
   });
 }

--- a/packages/apptive_grid_core/test/grid_test.dart
+++ b/packages/apptive_grid_core/test/grid_test.dart
@@ -362,9 +362,41 @@ void main() {
       final restored = Grid.fromJson(saved);
 
       expect(restored, equals(initialData));
-      expect(restored.hashCode, equals(initialData.hashCode));
       expect(restored.key, equals('gridKey'));
       expect(restored.hiddenFields!.first.id, equals('hiddenId'));
+    });
+
+    test('Hashcode', () {
+      final grid = Grid.fromJson(json);
+
+      expect(
+        grid.hashCode,
+        equals(
+          Object.hash(
+            grid.id,
+            grid.name,
+            grid.key,
+            grid.fields,
+            grid.hiddenFields,
+            grid.rows,
+            grid.filter,
+            grid.sorting,
+            grid.links,
+            grid.embeddedForms,
+          ),
+        ),
+      );
+    });
+
+    test('toString()', () {
+      final grid = Grid.fromJson(json);
+
+      expect(
+        grid.toString(),
+        equals(
+          'Grid(id: ${grid.id}, name: ${grid.name}, key: ${grid.key}, fields: ${grid.fields}, hiddenFields: ${grid.hiddenFields}, rows: ${grid.rows}, filter: ${grid.filter}, sorting: ${grid.sorting}, links: ${grid.links}, embeddedForms: ${grid.embeddedForms})',
+        ),
+      );
     });
   });
 }

--- a/packages/apptive_grid_core/test/multi_cross_reference_test.dart
+++ b/packages/apptive_grid_core/test/multi_cross_reference_test.dart
@@ -200,9 +200,42 @@ void main() {
       );
       expect(a, equals(b));
       expect(a, isNot(c));
+    });
 
-      expect(a.hashCode, equals(b.hashCode));
-      expect(a.hashCode, isNot(c.hashCode));
+    test('Hashcode', () {
+      final entity = MultiCrossReferenceDataEntity.fromJson(
+        jsonValue: [
+          {
+            'displayValue': 'Yeah!',
+            'uri':
+                '/api/users/userId/spaces/spaceId/grids/gridId/entities/entityId'
+          }
+        ],
+        gridUri: '/api/users/userId/spaces/spaceId/grids/referencedGridId',
+      );
+
+      expect(
+          entity.hashCode,
+          equals(Object.hash(entity.value,
+              '/api/users/userId/spaces/spaceId/grids/referencedGridId')));
+    });
+
+    test('toString()', () {
+      final entity = MultiCrossReferenceDataEntity.fromJson(
+        jsonValue: [
+          {
+            'displayValue': 'Yeah!',
+            'uri':
+                '/api/users/userId/spaces/spaceId/grids/gridId/entities/entityId'
+          }
+        ],
+        gridUri: '/api/users/userId/spaces/spaceId/grids/referencedGridId',
+      );
+
+      expect(
+          entity.toString(),
+          equals(
+              'MultiCrossReferenceDataEntity(references: [CrossReferenceDataEntity(displayValue: Yeah!, entityUri: /api/users/userId/spaces/spaceId/grids/gridId/entities/entityId, gridUri: /api/users/userId/spaces/spaceId/grids/referencedGridId)], gridUri: /api/users/userId/spaces/spaceId/grids/referencedGridId)'));
     });
   });
 
@@ -306,7 +339,30 @@ void main() {
       );
 
       expect(fromJson, equals(direct));
-      expect(fromJson.hashCode, equals(direct.hashCode));
+    });
+
+    test('Hashcode', () {
+      const field =
+          GridField(id: 'id', name: 'property', type: DataType.attachment);
+
+      final directEntity =
+          MultiCrossReferenceDataEntity(gridUri: Uri(path: 'gridUri'));
+      final component = FormComponent<MultiCrossReferenceDataEntity>(
+        property: 'New field',
+        data: directEntity,
+        field: field,
+      );
+
+      expect(
+        component.hashCode,
+        Object.hash(
+          component.field,
+          component.property,
+          component.data,
+          component.options,
+          component.required,
+        ),
+      );
     });
   });
 }

--- a/packages/apptive_grid_core/test/multi_cross_reference_test.dart
+++ b/packages/apptive_grid_core/test/multi_cross_reference_test.dart
@@ -215,9 +215,14 @@ void main() {
       );
 
       expect(
-          entity.hashCode,
-          equals(Object.hash(entity.value,
-              '/api/users/userId/spaces/spaceId/grids/referencedGridId')));
+        entity.hashCode,
+        equals(
+          Object.hash(
+            entity.value,
+            '/api/users/userId/spaces/spaceId/grids/referencedGridId',
+          ),
+        ),
+      );
     });
 
     test('toString()', () {
@@ -233,9 +238,11 @@ void main() {
       );
 
       expect(
-          entity.toString(),
-          equals(
-              'MultiCrossReferenceDataEntity(references: [CrossReferenceDataEntity(displayValue: Yeah!, entityUri: /api/users/userId/spaces/spaceId/grids/gridId/entities/entityId, gridUri: /api/users/userId/spaces/spaceId/grids/referencedGridId)], gridUri: /api/users/userId/spaces/spaceId/grids/referencedGridId)'));
+        entity.toString(),
+        equals(
+          'MultiCrossReferenceDataEntity(references: [CrossReferenceDataEntity(displayValue: Yeah!, entityUri: /api/users/userId/spaces/spaceId/grids/gridId/entities/entityId, gridUri: /api/users/userId/spaces/spaceId/grids/referencedGridId)], gridUri: /api/users/userId/spaces/spaceId/grids/referencedGridId)',
+        ),
+      );
     });
   });
 

--- a/packages/apptive_grid_core/test/sorting_test.dart
+++ b/packages/apptive_grid_core/test/sorting_test.dart
@@ -56,6 +56,14 @@ void main() {
       expect(sort1, isNot(sort3));
       expect(sort1.hashCode, isNot(sort3.hashCode));
     });
+
+    test('toString()', () {
+      const sorting =
+          ApptiveGridSorting(fieldId: 'fieldId', order: SortOrder.asc);
+
+      expect(sorting.toString(),
+          equals('ApptiveGridSorting({fieldId: ascending})'));
+    });
   });
 
   group('DistanceApptiveGridSorting', () {

--- a/packages/apptive_grid_core/test/sorting_test.dart
+++ b/packages/apptive_grid_core/test/sorting_test.dart
@@ -61,8 +61,10 @@ void main() {
       const sorting =
           ApptiveGridSorting(fieldId: 'fieldId', order: SortOrder.asc);
 
-      expect(sorting.toString(),
-          equals('ApptiveGridSorting({fieldId: ascending})'));
+      expect(
+        sorting.toString(),
+        equals('ApptiveGridSorting({fieldId: ascending})'),
+      );
     });
   });
 

--- a/packages/apptive_grid_core/test/space_test.dart
+++ b/packages/apptive_grid_core/test/space_test.dart
@@ -116,7 +116,6 @@ void main() {
         });
 
         expect(plain, equals(jsonSpace));
-        expect(plain.hashCode, equals(jsonSpace.hashCode));
       });
 
       test('Plain and From json not equal with different values', () {
@@ -141,8 +140,23 @@ void main() {
         });
 
         expect(plain, isNot(jsonSpace));
-        expect(plain.hashCode, isNot(jsonSpace.hashCode));
       });
+    });
+
+    test('Hashcode', () {
+      final space = Space(id: 'id', name: 'name', links: {});
+
+      expect(space.hashCode,
+          equals(Object.hash('id', 'name', null, null, space.links, null)));
+    });
+
+    test('toString()', () {
+      final space = Space(id: 'id', name: 'name', links: {});
+
+      expect(
+          space.toString(),
+          equals(
+              'Space(name: name, id: id, key: null, category: null, links: {}, embeddedGrids: null)'));
     });
   });
 
@@ -238,7 +252,6 @@ void main() {
         });
 
         expect(plain, equals(jsonSharedSpace));
-        expect(plain.hashCode, equals(jsonSharedSpace.hashCode));
       });
 
       test('Plain and From json not equal with different values', () {
@@ -292,8 +305,26 @@ void main() {
         });
 
         expect(plain, isNot(jsonSharedSpace));
-        expect(plain.hashCode, isNot(jsonSharedSpace.hashCode));
       });
+    });
+    test('Hashcode', () {
+      final space = SharedSpace(
+          realSpace: Uri(path: 'realSpace'), id: 'id', name: 'name', links: {});
+
+      expect(
+          space.hashCode,
+          equals(Object.hash('id', 'name', Uri(path: 'realSpace'), null, null,
+              space.links, null)));
+    });
+
+    test('toString()', () {
+      final space = SharedSpace(
+          realSpace: Uri(path: 'realSpace'), id: 'id', name: 'name', links: {});
+
+      expect(
+          space.toString(),
+          equals(
+              'SharedSpace(name: name, id: id, key: null, category: null, realSpace: realSpace, links: {}, embeddedGrids: null)'));
     });
   });
 }

--- a/packages/apptive_grid_core/test/space_test.dart
+++ b/packages/apptive_grid_core/test/space_test.dart
@@ -146,17 +146,21 @@ void main() {
     test('Hashcode', () {
       final space = Space(id: 'id', name: 'name', links: {});
 
-      expect(space.hashCode,
-          equals(Object.hash('id', 'name', null, null, space.links, null)));
+      expect(
+        space.hashCode,
+        equals(Object.hash('id', 'name', null, null, space.links, null)),
+      );
     });
 
     test('toString()', () {
       final space = Space(id: 'id', name: 'name', links: {});
 
       expect(
-          space.toString(),
-          equals(
-              'Space(name: name, id: id, key: null, category: null, links: {}, embeddedGrids: null)'));
+        space.toString(),
+        equals(
+          'Space(name: name, id: id, key: null, category: null, links: {}, embeddedGrids: null)',
+        ),
+      );
     });
   });
 
@@ -309,22 +313,42 @@ void main() {
     });
     test('Hashcode', () {
       final space = SharedSpace(
-          realSpace: Uri(path: 'realSpace'), id: 'id', name: 'name', links: {});
+        realSpace: Uri(path: 'realSpace'),
+        id: 'id',
+        name: 'name',
+        links: {},
+      );
 
       expect(
-          space.hashCode,
-          equals(Object.hash('id', 'name', Uri(path: 'realSpace'), null, null,
-              space.links, null)));
+        space.hashCode,
+        equals(
+          Object.hash(
+            'id',
+            'name',
+            Uri(path: 'realSpace'),
+            null,
+            null,
+            space.links,
+            null,
+          ),
+        ),
+      );
     });
 
     test('toString()', () {
       final space = SharedSpace(
-          realSpace: Uri(path: 'realSpace'), id: 'id', name: 'name', links: {});
+        realSpace: Uri(path: 'realSpace'),
+        id: 'id',
+        name: 'name',
+        links: {},
+      );
 
       expect(
-          space.toString(),
-          equals(
-              'SharedSpace(name: name, id: id, key: null, category: null, realSpace: realSpace, links: {}, embeddedGrids: null)'));
+        space.toString(),
+        equals(
+          'SharedSpace(name: name, id: id, key: null, category: null, realSpace: realSpace, links: {}, embeddedGrids: null)',
+        ),
+      );
     });
   });
 }

--- a/packages/apptive_grid_core/test/submit_form_progress_test.dart
+++ b/packages/apptive_grid_core/test/submit_form_progress_test.dart
@@ -98,7 +98,20 @@ void main() {
       );
 
       expect(event1, equals(event2));
-      expect(event1.hashCode, equals(event2.hashCode));
+    });
+
+    test('Hashcode', () {
+      final event1 = UploadFormProgressEvent(
+        FormData(
+          id: 'id',
+          name: 'form',
+          components: [],
+          fields: [],
+          links: {},
+        ),
+      );
+
+      expect(event1.hashCode, equals(event1.form.hashCode));
     });
   });
 

--- a/packages/apptive_grid_core/test/uri_test.dart
+++ b/packages/apptive_grid_core/test/uri_test.dart
@@ -136,7 +136,6 @@ void main() {
       expect(a, equals(b));
       expect(a, isNot(c));
 
-      expect(a.hashCode, equals(b.hashCode));
       expect(a.hashCode, isNot(c.hashCode));
     });
   });
@@ -207,7 +206,29 @@ void main() {
       );
 
       expect(fromJson.cast<UriDataEntity>(), equals(direct));
-      expect(fromJson.hashCode, equals(direct.hashCode));
+    });
+
+    test('Hashcode', () {
+      const field =
+          GridField(id: 'id', name: 'property', type: DataType.attachment);
+
+      final directEntity = UriDataEntity();
+      final component = FormComponent<UriDataEntity>(
+        property: 'New field',
+        data: directEntity,
+        field: field,
+      );
+
+      expect(
+        component.hashCode,
+        Object.hash(
+          component.field,
+          component.property,
+          component.data,
+          component.options,
+          component.required,
+        ),
+      );
     });
   });
 }

--- a/packages/apptive_grid_core/test/user_test.dart
+++ b/packages/apptive_grid_core/test/user_test.dart
@@ -157,8 +157,10 @@ void main() {
     });
 
     expect(
-        user.toString(),
-        equals(
-            'User(Jane Doe, email: jane.doe@zweidenker.de, id: id, links: {}, embeddedSpaces: null)'));
+      user.toString(),
+      equals(
+        'User(Jane Doe, email: jane.doe@zweidenker.de, id: id, links: {}, embeddedSpaces: null)',
+      ),
+    );
   });
 }

--- a/packages/apptive_grid_core/test/user_test.dart
+++ b/packages/apptive_grid_core/test/user_test.dart
@@ -87,7 +87,6 @@ void main() {
       });
 
       expect(plain, equals(jsonUser));
-      expect(plain.hashCode, equals(jsonUser.hashCode));
     });
 
     test('Plain and From json not equal with different values', () {
@@ -117,5 +116,49 @@ void main() {
       expect(plain, isNot(jsonUser));
       expect(plain.hashCode, isNot(jsonUser.hashCode));
     });
+  });
+
+  test('Hashcode is correct', () {
+    final user = User.fromJson({
+      'id': 'id',
+      'firstName': 'Jane',
+      'lastName': 'Doe',
+      'email': 'jane.doe@zweidenker.de',
+      'spaceUris': [
+        '/api/users/id/spaces/spaceId',
+      ],
+      '_links': {
+        'self': {'href': '/api/users/id', 'method': 'get'},
+      },
+    });
+
+    expect(
+      user.hashCode,
+      equals(
+        Object.hash(
+          user.id,
+          user.email,
+          user.lastName,
+          user.firstName,
+          user.links,
+          user.embeddedSpaces,
+        ),
+      ),
+    );
+  });
+
+  test('toString()', () {
+    final user = User.fromJson({
+      'id': 'id',
+      'firstName': 'Jane',
+      'lastName': 'Doe',
+      'email': 'jane.doe@zweidenker.de',
+      '_links': <String, dynamic>{},
+    });
+
+    expect(
+        user.toString(),
+        equals(
+            'User(Jane Doe, email: jane.doe@zweidenker.de, id: id, links: {}, embeddedSpaces: null)'));
   });
 }

--- a/packages/apptive_grid_form/lib/configurations/geolocation_form_widget_configuration.dart
+++ b/packages/apptive_grid_form/lib/configurations/geolocation_form_widget_configuration.dart
@@ -32,5 +32,5 @@ class GeolocationFormWidgetConfiguration extends FormWidgetConfiguration {
   }
 
   @override
-  int get hashCode => toString().hashCode;
+  int get hashCode => Object.hash(placesApiKey, geocodingApiKey);
 }

--- a/packages/apptive_grid_form/test/geocoding/geolocation_form_widget_configuration_test.dart
+++ b/packages/apptive_grid_form/test/geocoding/geolocation_form_widget_configuration_test.dart
@@ -16,6 +16,5 @@ void main() {
     );
 
     expect(a, equals(b));
-    expect(a.hashCode, equals(b.hashCode));
   });
 }


### PR DESCRIPTION
Make sure Hashcode Functions generate Hashes based on their Object instead of their toString() methods. Also make sure that the toString() methods are correct