### PR TITLE
ci: Adjust Versioning Job

### DIFF
--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,9 +1,8 @@
 name: Versioning
 
 on:
-  push:
-    branches:
-      - main
+  workflow_dispatch:
+    
 
 jobs:
   versioning:

--- a/.github/workflows/versioning.yml
+++ b/.github/workflows/versioning.yml
@@ -1,8 +1,7 @@
 name: Versioning
 
 on:
-  workflow_dispatch:
-    
+  workflow_dispatch:    
 
 jobs:
   versioning:
@@ -15,11 +14,13 @@ jobs:
           # Make sure that VERSION_PAT is a valid PAT with Read/Write Access to the Repository's content
           # Also make sure that the Token is allowed to bypass Branch Protection Rules
           token: ${{ secrets.VERSION_PAT }}
+          # Always use main branch even if different branch was selected
+          ref: main
       - uses: subosito/flutter-action@v2
       - uses: bluefireteam/melos-action@v1
 
       - name: Versioning
-        run: melos version
+        run: melos version --yes
 
       - name: Commit and Push Changes
         uses: stefanzweifel/git-auto-commit-action@v4


### PR DESCRIPTION
- Adjust Versioning Job to be triggered by a workflow_dispatch instead of a push on master.
- Always checkout main branch in versioning to make sure workflow_dispatch is not accidentally run on a wrong branch.
- Skip yes verification for Version command