### PR TITLE
feat: Better Hal Version Support

### DIFF
--- a/packages/apptive_grid_core/lib/src/apptive_grid_network.dart
+++ b/packages/apptive_grid_core/lib/src/apptive_grid_network.dart
@@ -8,3 +8,4 @@ export 'package:apptive_grid_core/src/network/authentication/web_auth_enabler/we
 export 'package:apptive_grid_core/src/network/environment.dart';
 export 'package:apptive_grid_core/src/network/filter/apptive_grid_filter.dart';
 export 'package:apptive_grid_core/src/network/sorting/apptive_grid_sorting.dart';
+export 'package:apptive_grid_core/src/network/version/apptive_grid_hal_version.dart';

--- a/packages/apptive_grid_core/lib/src/network/apptive_grid_client.dart
+++ b/packages/apptive_grid_core/lib/src/network/apptive_grid_client.dart
@@ -539,6 +539,7 @@ class ApptiveGridClient extends ChangeNotifier {
   /// Get a specific entity via a [uri]
   ///
   /// [headers] will be added in addition to [ApptiveGridClient.defaultHeaders]
+  /// [halVersion] describes what Hal Version of ApptiveGrid should be used.
   ///
   /// This will return a Map of fieldIds and the respective values
   /// To know what [DataType] they are you need to Load a Grid via [loadGrid] and compare [Grid.fields] with the ids

--- a/packages/apptive_grid_core/lib/src/network/apptive_grid_client.dart
+++ b/packages/apptive_grid_core/lib/src/network/apptive_grid_client.dart
@@ -72,11 +72,14 @@ class ApptiveGridClient extends ChangeNotifier {
           .map((key, value) => MapEntry(key, value!));
 
   Map<String, String> _createHeadersWithDefaults(
-    Map<String, String> customHeader,
-  ) {
-    final newHeader = defaultHeaders;
-    newHeader.addAll(customHeader);
-    return newHeader;
+    Map<String, String> customHeader, [
+    ApptiveGridHalVersion? halVersion,
+  ]) {
+    return {
+      ...defaultHeaders,
+      if (halVersion != null) ...Map.fromEntries([halVersion.header]),
+      ...customHeader,
+    };
   }
 
   Uri _generateApptiveGridUri(Uri baseUri) {
@@ -359,7 +362,7 @@ class ApptiveGridClient extends ChangeNotifier {
     final gridViewUrl = _generateApptiveGridUri(uri);
 
     final gridHeaders = _createHeadersWithDefaults(headers);
-    gridHeaders['Accept'] = 'application/vnd.apptivegrid.hal;version=2';
+    gridHeaders.addEntries([ApptiveGridHalVersion.v2.header]);
     final gridViewResponse =
         await _client.get(gridViewUrl, headers: gridHeaders);
     if (gridViewResponse.statusCode >= 400) {
@@ -400,6 +403,7 @@ class ApptiveGridClient extends ChangeNotifier {
   /// [sorting] allows to apply custom sorting
   /// [filter] allows to get custom filters
   /// [headers] will be added in addition to [ApptiveGridClient.defaultHeaders]
+  /// [halVersion] describes what Hal Version of ApptiveGrid should be used. This can effect the format and features of the response and might break parsing.
   /// [pageIndex] is the index of the page to be loaded.
   /// [pageSize] is the requested item count in the loaded page.
   /// Paging currently requireds the header to contain `'accept': 'application/vnd.apptivegrid.hal'`.
@@ -410,6 +414,7 @@ class ApptiveGridClient extends ChangeNotifier {
     ApptiveGridFilter? filter,
     bool isRetry = false,
     Map<String, String> headers = const {},
+    ApptiveGridHalVersion? halVersion,
     int? pageIndex,
     int? pageSize,
   }) async {
@@ -431,7 +436,7 @@ class ApptiveGridClient extends ChangeNotifier {
 
     final response = await _client.get(
       requestUri,
-      headers: _createHeadersWithDefaults(headers),
+      headers: _createHeadersWithDefaults(headers, halVersion),
     );
 
     if (response.statusCode >= 400) {
@@ -446,6 +451,7 @@ class ApptiveGridClient extends ChangeNotifier {
           headers: headers,
           pageIndex: pageIndex,
           pageSize: pageSize,
+          halVersion: halVersion,
         );
       }
       throw response;
@@ -487,8 +493,10 @@ class ApptiveGridClient extends ChangeNotifier {
     await authenticator.checkAuthentication();
 
     final url = _generateApptiveGridUri(uri);
-    final response =
-        await _client.get(url, headers: _createHeadersWithDefaults(headers));
+    final response = await _client.get(
+      url,
+      headers: _createHeadersWithDefaults(headers),
+    );
     if (response.statusCode >= 400) {
       throw response;
     }
@@ -540,6 +548,7 @@ class ApptiveGridClient extends ChangeNotifier {
   Future<dynamic> getEntity({
     required Uri uri,
     Map<String, String> headers = const {},
+    ApptiveGridHalVersion? halVersion,
     ApptiveGridLayout layout = ApptiveGridLayout.field,
   }) async {
     await authenticator.checkAuthentication();
@@ -552,7 +561,7 @@ class ApptiveGridClient extends ChangeNotifier {
           'layout': layout.queryParameter,
         },
       ),
-      headers: _createHeadersWithDefaults(headers),
+      headers: _createHeadersWithDefaults(headers, halVersion),
     );
 
     if (response.statusCode >= 400) {
@@ -664,6 +673,7 @@ class ApptiveGridClient extends ChangeNotifier {
   /// Perform a action represented by [link]
   /// [body] is the body of the request
   /// [headers] will be added in addition to [ApptiveGridClient.defaultHeaders]
+  /// [halVersion] describes what Hal Version of ApptiveGrid should be used
   /// [queryParameters] will override any [queryParameters] in [ApptiveLink.uri]
   /// [parseResponse] will be called with [http.Response] if the request has been successful
   Future<T?> performApptiveLink<T>({
@@ -671,6 +681,7 @@ class ApptiveGridClient extends ChangeNotifier {
     bool isRetry = false,
     dynamic body,
     Map<String, String> headers = const {},
+    ApptiveGridHalVersion? halVersion,
     Map<String, String>? queryParameters,
     required Future<T?> Function(http.Response response) parseResponse,
   }) async {
@@ -685,7 +696,7 @@ class ApptiveGridClient extends ChangeNotifier {
       request.body = json.encode(body);
     }
 
-    request.headers.addAll(_createHeadersWithDefaults(headers));
+    request.headers.addAll(_createHeadersWithDefaults(headers, halVersion));
 
     final streamResponse = await _client.send(request);
     final response = await http.Response.fromStream(streamResponse);

--- a/packages/apptive_grid_core/lib/src/network/version/apptive_grid_hal_version.dart
+++ b/packages/apptive_grid_core/lib/src/network/version/apptive_grid_hal_version.dart
@@ -1,10 +1,17 @@
+/// Enumeration of possible HalVersion to be used to enable specific features/formats of responses
 enum ApptiveGridHalVersion {
+  /// The first version of hal
   v1(headerValue: 'application/vnd.apptivegrid.hal'),
+
+  /// Second Version adding functionality to calls/models that already have specific behaviour for [v1]
   v2(headerValue: 'application/vnd.apptivegrid.hal;version=2');
 
+  /// Constructor for Enum with [halVersion]
   const ApptiveGridHalVersion({required this.headerValue});
 
+  /// Value that should be send as an [Accept] Header in a request in order for the halVersion to take effect
   final String headerValue;
 
+  /// A MapEntry to be used in a Header Map. Sets [headerValue] as the `Accept` value
   MapEntry<String, String> get header => MapEntry('Accept', headerValue);
 }

--- a/packages/apptive_grid_core/lib/src/network/version/apptive_grid_hal_version.dart
+++ b/packages/apptive_grid_core/lib/src/network/version/apptive_grid_hal_version.dart
@@ -1,0 +1,10 @@
+enum ApptiveGridHalVersion {
+  v1(headerValue: 'application/vnd.apptivegrid.hal'),
+  v2(headerValue: 'application/vnd.apptivegrid.hal;version=2');
+
+  const ApptiveGridHalVersion({required this.headerValue});
+
+  final String headerValue;
+
+  MapEntry<String, String> get header => MapEntry('Accept', headerValue);
+}

--- a/packages/apptive_grid_core/test/apptive_grid_hal_version_test.dart
+++ b/packages/apptive_grid_core/test/apptive_grid_hal_version_test.dart
@@ -1,0 +1,15 @@
+import 'package:apptive_grid_core/apptive_grid_core.dart';
+import 'package:flutter_test/flutter_test.dart';
+
+void main() {
+  test('v1', () {
+    final header = ApptiveGridHalVersion.v1.header;
+    expect(header.key, 'Accept');
+    expect(header.value, 'application/vnd.apptivegrid.hal');
+  });
+  test('v2', () {
+    final header = ApptiveGridHalVersion.v2.header;
+    expect(header.key, 'Accept');
+    expect(header.value, 'application/vnd.apptivegrid.hal;version=2');
+  });
+}


### PR DESCRIPTION
- Add `ApptiveGridHalVersion` enum that generates appropiate Headers
- Add `halVersion` as optional parameters to `loadEntities`, `getEntities` and `performApptiveLink` calls in client

I decided against adding the parameter to all calls for the following reasons:
1. Using hal version can change layouts that may break parsing into models like forms
2. If needed the HalVersion Header can still be added by using the `header` parameter that is present for all calls. Adding the correct value is now cleaner and easier through the enum