### PR TITLE
fix: Enforce country codes for phone numbers in forms

### DIFF
--- a/packages/apptive_grid_form/lib/src/translation/apptive_grid_translation.dart
+++ b/packages/apptive_grid_form/lib/src/translation/apptive_grid_translation.dart
@@ -83,4 +83,7 @@ abstract class ApptiveGridTranslation {
 
   /// Prompt to sign in the field
   String get signHere;
+
+  /// Hint that a phonenumber need to start with a country code
+  String get missingCountryCode;
 }

--- a/packages/apptive_grid_form/lib/src/translation/l10n/intl_de.json
+++ b/packages/apptive_grid_form/lib/src/translation/l10n/intl_de.json
@@ -24,5 +24,6 @@
     "invalidEmail": "Ungültige E-Mail",
     "clear": "Korrigieren",
     "save": "Speichern",
-    "signHere": "Hier unterschreiben"
+    "signHere": "Hier unterschreiben",
+    "missingCountryCode": "Eine Ländervorwahl wird erwartet (z.B. +49)"
 }

--- a/packages/apptive_grid_form/lib/src/translation/l10n/intl_en.json
+++ b/packages/apptive_grid_form/lib/src/translation/l10n/intl_en.json
@@ -24,5 +24,6 @@
     "invalidEmail": "Invalid email",
     "clear": "Clear",
     "save": "Save",
-    "signHere": "Sign here"
+    "signHere": "Sign here",
+    "missingCountryCode": "International code is required (e.g. +49)"
 }

--- a/packages/apptive_grid_form/lib/src/translation/l10n/translation_de.dart
+++ b/packages/apptive_grid_form/lib/src/translation/l10n/translation_de.dart
@@ -63,4 +63,7 @@ class ApptiveGridLocalizedTranslation extends ApptiveGridTranslation {
   String get save => "Speichern";
   @override
   String get signHere => "Hier unterschreiben";
+  @override
+  String get missingCountryCode =>
+      "Eine Ländervorwahl wird erwartet (z.B. +49)";
 }

--- a/packages/apptive_grid_form/lib/src/translation/l10n/translation_en.dart
+++ b/packages/apptive_grid_form/lib/src/translation/l10n/translation_en.dart
@@ -63,4 +63,6 @@ class ApptiveGridLocalizedTranslation extends ApptiveGridTranslation {
   String get save => "Save";
   @override
   String get signHere => "Sign here";
+  @override
+  String get missingCountryCode => "International code is required (e.g. +49)";
 }

--- a/packages/apptive_grid_form/lib/src/widgets/form_widget/phone_number_form_widget.dart
+++ b/packages/apptive_grid_form/lib/src/widgets/form_widget/phone_number_form_widget.dart
@@ -56,7 +56,7 @@ class _PhoneNumberFormWidgetState extends State<PhoneNumberFormWidget>
         } else if (input != null &&
             input.isNotEmpty &&
             !_strictRegex.hasMatch(input)) {
-          return 'must start with a country code';
+          return ApptiveGridLocalization.of(context)!.missingCountryCode;
         } else {
           return null;
         }

--- a/packages/apptive_grid_form/lib/src/widgets/form_widget/phone_number_form_widget.dart
+++ b/packages/apptive_grid_form/lib/src/widgets/form_widget/phone_number_form_widget.dart
@@ -41,6 +41,9 @@ class _PhoneNumberFormWidgetState extends State<PhoneNumberFormWidget>
     super.dispose();
   }
 
+  final _strictRegex = RegExp(r'^\+[\d]+$');
+  final _inputRegex = RegExp(r'^\+*[\d]*$');
+
   @override
   Widget build(BuildContext context) {
     super.build(context);
@@ -50,13 +53,17 @@ class _PhoneNumberFormWidgetState extends State<PhoneNumberFormWidget>
         if (widget.component.required && (input == null || input.isEmpty)) {
           return ApptiveGridLocalization.of(context)!
               .fieldIsRequired(widget.component.property);
+        } else if (input != null &&
+            input.isNotEmpty &&
+            !_strictRegex.hasMatch(input)) {
+          return 'must start with a country code';
         } else {
           return null;
         }
       },
       autovalidateMode: AutovalidateMode.onUserInteraction,
       inputFormatters: [
-        FilteringTextInputFormatter.allow(RegExp(r'^\+*[\d]*')),
+        FilteringTextInputFormatter.allow(_inputRegex),
       ],
       minLines: 1,
       maxLines: 1,

--- a/packages/apptive_grid_form/test/phone_number_form_widget_test.dart
+++ b/packages/apptive_grid_form/test/phone_number_form_widget_test.dart
@@ -120,6 +120,18 @@ void main() {
         findsNothing,
       );
 
+      const incompletePhoneNumber = '12345';
+      await tester.enterText(phonenumberField, incompletePhoneNumber);
+      await tester.pumpAndSettle();
+
+      expect(
+        find.text(
+          'International code is required (e.g. +49)',
+          skipOffstage: true,
+        ),
+        findsOneWidget,
+      );
+
       const validPhoneNumber = '+12345';
       await tester.enterText(phonenumberField, validPhoneNumber);
       await tester.pumpAndSettle();


### PR DESCRIPTION
Force a phone number to start with a `+` and at least 1 number