### PR TITLE
fix: Handle Confirming already confirmed registration

### DIFF
--- a/packages/apptive_grid_user_management/example/lib/main.dart
+++ b/packages/apptive_grid_user_management/example/lib/main.dart
@@ -43,18 +43,22 @@ class MyApp extends StatelessWidget {
             onAccountConfirmed: (loggedIn) {
               // Account was confirmed
               // go to login screen if [loggedIn] is false
-              ScaffoldMessenger.of(context).showSnackBar(
+              ScaffoldMessenger.of(_navigatorKey.currentContext!).showSnackBar(
                 SnackBar(
                   content: Text('Account Confirmed. LoggedIn: $loggedIn'),
                 ),
               );
-              Navigator.of(context).pushReplacement(
-                MaterialPageRoute(
-                  builder: (_) {
-                    return const AccountPage();
-                  },
-                ),
-              );
+              if (loggedIn) {
+                Navigator.of(context).pushReplacement(
+                  MaterialPageRoute(
+                    builder: (_) {
+                      return const AccountPage();
+                    },
+                  ),
+                );
+              } else {
+                _navigatorKey.currentState?.pop();
+              }
             },
             resetPasswordPrompt: (resetPasswordWidget) {
               // Show [resetPasswordWidget] to allow Users to set a new password

--- a/packages/apptive_grid_user_management/lib/src/confirm_account.dart
+++ b/packages/apptive_grid_user_management/lib/src/confirm_account.dart
@@ -92,7 +92,9 @@ class _ConfirmAccountState extends State<ConfirmAccount> {
       return error;
     });
 
-    if (confirmResponse != null && confirmResponse.statusCode < 400) {
+    if (confirmResponse != null &&
+        (confirmResponse.statusCode < 400 ||
+            (confirmResponse.body.startsWith('No registration found')))) {
       final loggedIn = await client?.loginAfterConfirmation() ?? false;
       widget.confirmAccount.call(loggedIn);
     }


### PR DESCRIPTION
- Handle `No Registration found` to also perform login check and call `onConfirm` callback