### PR TITLE
refactor: Use performApptiveLink for Client Functions

### DIFF
--- a/packages/apptive_grid_core/lib/src/network/apptive_grid_client.dart
+++ b/packages/apptive_grid_core/lib/src/network/apptive_grid_client.dart
@@ -103,23 +103,16 @@ class ApptiveGridClient extends ChangeNotifier {
     final url = _generateApptiveGridUri(uri);
     final sanitizedUrl =
         url.replace(path: url.path.replaceAll(RegExp('/r/'), '/a/'));
-    final response = await _client.get(
-      sanitizedUrl,
-      headers: _createHeadersWithDefaults(headers),
+
+    final data = await performApptiveLink<FormData>(
+      link: ApptiveLink(uri: sanitizedUrl, method: 'get'),
+      headers: headers,
+      parseResponse: (response) async {
+        return FormData.fromJson(json.decode(response.body));
+      },
     );
-    if (response.statusCode >= 400) {
-      if (response.statusCode == 401 && !isRetry) {
-        await authenticator.checkAuthentication();
-        return loadForm(
-          uri: uri,
-          headers: headers,
-          isRetry: true,
-        );
-      } else {
-        throw response;
-      }
-    }
-    return FormData.fromJson(json.decode(response.body));
+
+    return data!;
   }
 
   /// Submits [formData] against [link]
@@ -346,26 +339,15 @@ class ApptiveGridClient extends ChangeNotifier {
     Map<String, String> headers = const {},
     bool loadEntities = true,
   }) async {
-    final gridViewUrl = _generateApptiveGridUri(uri);
+    final gridViewResponse = await performApptiveLink<http.Response>(
+      link: ApptiveLink(uri: uri, method: 'get'),
+      headers: headers,
+      halVersion: ApptiveGridHalVersion.v2,
+      isRetry: isRetry,
+      parseResponse: (response) async => response,
+    );
 
-    final gridHeaders = _createHeadersWithDefaults(headers);
-    gridHeaders.addEntries([ApptiveGridHalVersion.v2.header]);
-    final gridViewResponse =
-        await _client.get(gridViewUrl, headers: gridHeaders);
-    if (gridViewResponse.statusCode >= 400) {
-      if (gridViewResponse.statusCode == 401 && !isRetry) {
-        await authenticator.checkAuthentication();
-        return loadGrid(
-          uri: uri,
-          sorting: sorting,
-          filter: filter,
-          isRetry: true,
-        );
-      }
-      throw gridViewResponse;
-    }
-
-    final gridToParse = jsonDecode(gridViewResponse.body);
+    final gridToParse = jsonDecode(gridViewResponse!.body);
     final grid = Grid.fromJson(gridToParse);
     if (loadEntities && grid.links.containsKey(ApptiveLinkType.entities)) {
       final entitiesResponse = await this.loadEntities(
@@ -393,7 +375,7 @@ class ApptiveGridClient extends ChangeNotifier {
   /// [halVersion] describes what Hal Version of ApptiveGrid should be used. This can effect the format and features of the response and might break parsing.
   /// [pageIndex] is the index of the page to be loaded.
   /// [pageSize] is the requested item count in the loaded page.
-  /// Paging currently requireds the header to contain `'accept': 'application/vnd.apptivegrid.hal'`.
+  /// Paging currently requires the header to contain `'accept': 'application/vnd.apptivegrid.hal'`.
   Future<EntitiesResponse<T>> loadEntities<T>({
     required Uri uri,
     ApptiveGridLayout layout = ApptiveGridLayout.field,
@@ -405,10 +387,8 @@ class ApptiveGridClient extends ChangeNotifier {
     int? pageIndex,
     int? pageSize,
   }) async {
-    final baseUrl = Uri.parse(options.environment.url);
-    final requestUri = uri.replace(
-      scheme: baseUrl.scheme,
-      host: baseUrl.host,
+    return (await performApptiveLink(
+      link: ApptiveLink(uri: uri, method: 'get'),
       queryParameters: {
         'layout': layout.queryParameter,
         if (sorting != null)
@@ -417,34 +397,13 @@ class ApptiveGridClient extends ChangeNotifier {
         if (filter != null) 'filter': jsonEncode(filter.toJson()),
         if (pageIndex != null) 'pageIndex': '$pageIndex',
         if (pageSize != null) 'pageSize': '$pageSize',
-        ...uri.queryParameters,
       },
-    );
-
-    final response = await _client.get(
-      requestUri,
-      headers: _createHeadersWithDefaults(headers, halVersion),
-    );
-
-    if (response.statusCode >= 400) {
-      if (response.statusCode == 401 && !isRetry) {
-        await authenticator.checkAuthentication();
-        return loadEntities<T>(
-          uri: uri,
-          layout: layout,
-          sorting: sorting,
-          filter: filter,
-          isRetry: true,
-          headers: headers,
-          pageIndex: pageIndex,
-          pageSize: pageSize,
-          halVersion: halVersion,
-        );
-      }
-      throw response;
-    }
-
-    return EntitiesResponse<T>.fromJson(jsonDecode(response.body));
+      halVersion: halVersion,
+      isRetry: isRetry,
+      headers: headers,
+      parseResponse: (response) async =>
+          EntitiesResponse<T>.fromJson(jsonDecode(response.body)),
+    ))!;
   }
 
   /// Get the [User] that is authenticated
@@ -461,12 +420,12 @@ class ApptiveGridClient extends ChangeNotifier {
     await authenticator.checkAuthentication();
 
     final url = Uri.parse('${options.environment.url}/api/users/me');
-    final response =
-        await _client.get(url, headers: _createHeadersWithDefaults(headers));
-    if (response.statusCode >= 400) {
-      throw response;
-    }
-    return User.fromJson(json.decode(response.body));
+    return (await performApptiveLink<User>(
+      link: ApptiveLink(uri: url, method: 'get'),
+      headers: headers,
+      parseResponse: (response) async =>
+          User.fromJson(json.decode(response.body)),
+    ))!;
   }
 
   /// Get the [Space] represented by [spaceUri]
@@ -480,23 +439,13 @@ class ApptiveGridClient extends ChangeNotifier {
     Map<String, String> headers = const {},
     bool isRetry = false,
   }) async {
-    final url = _generateApptiveGridUri(uri);
-    final response = await _client.get(
-      url,
-      headers: _createHeadersWithDefaults(headers),
-    );
-    if (response.statusCode >= 400) {
-      if (response.statusCode == 401 && !isRetry) {
-        await authenticator.checkAuthentication();
-        return getSpace(
-          uri: uri,
-          headers: headers,
-          isRetry: true,
-        );
-      }
-      throw response;
-    }
-    return Space.fromJson(json.decode(response.body));
+    return (await performApptiveLink<Space>(
+      link: ApptiveLink(uri: uri, method: 'get'),
+      headers: headers,
+      isRetry: isRetry,
+      parseResponse: (response) async =>
+          Space.fromJson(json.decode(response.body)),
+    ))!;
   }
 
   /// Creates and returns a [Uri] pointing to a Form filled with the Data represented for a given entitiy
@@ -511,33 +460,18 @@ class ApptiveGridClient extends ChangeNotifier {
     Map<String, String> headers = const {},
     bool isRetry = false,
   }) async {
-    final url = _generateApptiveGridUri(uri);
-
-    final response = await _client.post(
-      url,
-      headers: _createHeadersWithDefaults(headers),
+    return (await performApptiveLink<Uri>(
+      link: ApptiveLink(uri: uri, method: 'post'),
       body: jsonEncode({
         'formId': formId,
       }),
-    );
-
-    if (response.statusCode >= 400) {
-      if (response.statusCode == 401 && !isRetry) {
-        await authenticator.checkAuthentication();
-        return getEditLink(
-          uri: uri,
-          formId: formId,
-          headers: headers,
-          isRetry: true,
-        );
-      }
-      throw response;
-    }
-
-    return Uri.parse(
-      ((json.decode(response.body) as Map)['uri'] as String)
-          .replaceAll(RegExp('/r/'), '/a/'),
-    );
+      headers: headers,
+      isRetry: isRetry,
+      parseResponse: (response) async => Uri.parse(
+        ((json.decode(response.body) as Map)['uri'] as String)
+            .replaceAll(RegExp('/r/'), '/a/'),
+      ),
+    ))!;
   }
 
   /// Get a specific entity via a [uri]
@@ -557,32 +491,20 @@ class ApptiveGridClient extends ChangeNotifier {
     ApptiveGridLayout layout = ApptiveGridLayout.field,
     bool isRetry = false,
   }) async {
-    final url = _generateApptiveGridUri(uri);
-
-    final response = await _client.get(
-      url.replace(
-        queryParameters: {
-          'layout': layout.queryParameter,
-        },
+    return performApptiveLink(
+      link: ApptiveLink(
+        uri: uri.replace(
+          queryParameters: {
+            'layout': layout.queryParameter,
+          },
+        ),
+        method: 'get',
       ),
-      headers: _createHeadersWithDefaults(headers, halVersion),
+      headers: headers,
+      halVersion: halVersion,
+      isRetry: isRetry,
+      parseResponse: (response) async => response.body,
     );
-
-    if (response.statusCode >= 400) {
-      if (response.statusCode == 401 && !isRetry) {
-        await authenticator.checkAuthentication();
-        return getEntity(
-          uri: uri,
-          headers: headers,
-          halVersion: halVersion,
-          layout: layout,
-          isRetry: true,
-        );
-      }
-      throw response;
-    }
-
-    return jsonDecode(response.body);
   }
 
   /// Authenticate the User

--- a/packages/apptive_grid_form/test/apptive_grid_form_test.dart
+++ b/packages/apptive_grid_form/test/apptive_grid_form_test.dart
@@ -880,16 +880,20 @@ void main() {
     setUp(() {
       httpClient = MockHttpClient();
 
-      when(
-        () => httpClient.get(
-          Uri.parse(env.url + formUri.toString()),
-          headers: any(named: 'headers'),
-        ),
-      ).thenAnswer(
-        (_) async => http.Response(jsonEncode(data.toJson()), 200),
-      );
       when(() => httpClient.send(any())).thenAnswer(
-        (invocation) async => http.StreamedResponse(Stream.value([]), 400),
+        (invocation) async {
+          final request =
+              invocation.positionalArguments.first as http.BaseRequest;
+          if (request.url.path ==
+              Uri.parse(env.url + formUri.toString()).path) {
+            return http.StreamedResponse(
+              Stream.value(utf8.encode(jsonEncode(data.toJson()))),
+              200,
+            );
+          } else {
+            return http.StreamedResponse(Stream.value([]), 400);
+          }
+        },
       );
     });
 
@@ -946,7 +950,15 @@ void main() {
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
 
-      verify(() => httpClient.send(any())).called(1);
+      verify(
+        () => httpClient.send(
+          any(
+            that: predicate<http.BaseRequest>(
+              (request) => request.method == 'POST',
+            ),
+          ),
+        ),
+      ).called(1);
 
       expect(
         find.text(
@@ -995,7 +1007,15 @@ void main() {
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
 
-      verify(() => httpClient.send(any())).called(1);
+      verify(
+        () => httpClient.send(
+          any(
+            that: predicate<http.BaseRequest>(
+              (request) => request.method == 'POST',
+            ),
+          ),
+        ),
+      ).called(1);
 
       expect(
         find.text(
@@ -1047,7 +1067,15 @@ void main() {
       await tester.tap(find.byType(ElevatedButton));
       await tester.pumpAndSettle();
 
-      verify(() => httpClient.send(any())).called(1);
+      verify(
+        () => httpClient.send(
+          any(
+            that: predicate<http.BaseRequest>(
+              (request) => request.method == 'POST',
+            ),
+          ),
+        ),
+      ).called(1);
 
       expect(
         find.text(


### PR DESCRIPTION
This refactors all functions that make a call for ApptiveGrid Objects (like `loadGrid`, `loadForm`,...) to use `performApptiveLink`

This removes a lot of copied code as the retry/auth logic now is not necessary in each of the functions but rather centrally in the performApptiveLink function. While the diff in the whole PR looks like not much was changed this is mostly due to the mock calls now needing more code as it uses `client.send` now. If you look just at the change in the actual client you can see that we managed to get rid of almost 80 lines of code (beb5697a4cfd2f17c5505a725f2a30c8ad7ac0a7) 

