### PR TITLE
fix: bump hand_signature to ^3.1.0

### DIFF
--- a/packages/apptive_grid_form/pubspec.yaml
+++ b/packages/apptive_grid_form/pubspec.yaml
@@ -19,7 +19,7 @@ dependencies:
   geolocator: ^10.0.1
   google_maps_flutter: ^2.9.0
   google_maps_flutter_platform_interface: ^2.9.0
-  hand_signature: ^3.0.1
+  hand_signature: ^3.1.0
   http: '>=0.13.6 <2.0.0'
   image_picker: ^1.0.4
   intl: ^0.20.0


### PR DESCRIPTION
## Summary
- `addPath` was introduced in `hand_signature 3.1.0` but the constraint was `^3.0.1`, causing a runtime error when loading prefilled signatures
- Bumps constraint to `^3.1.0` (resolves to `3.1.0+2`)

## Test plan
- [x] All 259 existing signature tests pass
- [x] `dart analyze` — no issues
- [x] `dart format` — no changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)