### PR TITLE
fix: only listen for auth redirect when a redirect scheme is set

### DIFF
--- a/packages/apptive_grid_core/lib/src/network/authentication/apptive_grid_authenticator.dart
+++ b/packages/apptive_grid_core/lib/src/network/authentication/apptive_grid_authenticator.dart
@@ -51,7 +51,13 @@ class ApptiveGridAuthenticator {
   /// and listening to authentication callbacks
   Future<void> performSetup() async {
     _setupCompleter = Completer();
-    if (!kIsWeb) {
+    // Only listen for auth redirects when a redirect scheme is configured.
+    // Otherwise a second client without a redirect scheme (e.g. one created by
+    // an `ApptiveGrid` widget with default options) would subscribe to the same
+    // app_links stream and swallow the redirect meant for the authenticating
+    // client, leaving the login hanging.
+    if (!kIsWeb &&
+        client.options.authenticationOptions.redirectScheme != null) {
       _authCallbackSubscription?.cancel();
       _authCallbackSubscription = AppLinksPlatform.instance.uriLinkStream
           .where(

--- a/packages/apptive_grid_core/lib/src/network/authentication/authentication_storage.dart
+++ b/packages/apptive_grid_core/lib/src/network/authentication/authentication_storage.dart
@@ -30,7 +30,7 @@ class FlutterSecureStorageCredentialStorage implements AuthenticationStorage {
       _flutterSecureStorage.read(key: _credentialKey);
 
   @override
-  FutureOr<void> saveCredential(String? credential) {
-    _flutterSecureStorage.write(key: _credentialKey, value: credential);
+  Future<void> saveCredential(String? credential) async {
+    await _flutterSecureStorage.write(key: _credentialKey, value: credential);
   }
 }


### PR DESCRIPTION
## Problem

Login (OAuth redirect) broke for consumers after **2.1.7** switched from `uni_links` to `app_links` (part of the Flutter 3.44 dependency update).

`app_links`' `uriLinkStream` delivers a redirect to a **single** subscriber. When an app creates a second `ApptiveGridClient` **without** a redirect scheme — e.g. an `ApptiveGrid` widget using default `ApptiveGridOptions` — its authenticator also subscribed to the stream and **swallowed** the `redirectScheme://…?code=…` callback meant for the authenticating client. Its filter `where(event.scheme == null)` dropped the `apptiveteams` event, so `authorize()` never completed and the login browser stayed open.

Verified on iOS with logging: the `apptiveteams://…` event arrived but `_handleAuthRedirect` was never called (wrong subscriber). With `uni_links` (≤2.1.6) the stream behaved differently, so this only surfaced after the upgrade.

## Fix

- Only subscribe to the redirect stream when a `redirectScheme` is configured — an authenticator without one cannot handle a redirect anyway, so it must not consume it.
- Also `await` the secure-storage write in `saveCredential` so the credential is actually persisted before continuing (was fire-and-forget).

## Test

- `flutter analyze` clean.
- Manually verified end-to-end on iOS via a consuming app (ApptiveTeams): email login now completes, token is stored, app reaches the team selection. Before the fix the login browser hung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)