### PR TITLE
chore(release): apptive_grid_core 2.1.8, apptive_grid_form 2.2.1

### DIFF
--- a/packages/apptive_grid_core/CHANGELOG.md
+++ b/packages/apptive_grid_core/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.1.8
+
+ - **FIX**: Only listen for auth redirect when a redirect scheme is set (#147).
+
 ## 2.1.7
 
  - **CHORE**: Update dependencies for Flutter 3.44.0 compatibility.

--- a/packages/apptive_grid_core/pubspec.yaml
+++ b/packages/apptive_grid_core/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_core
 description: Core Library for ApptiveGrid used to provide general ApptiveGrid functionality to other Packages or Apps
-version: 2.1.7
+version: 2.1.8
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_core
 

--- a/packages/apptive_grid_form/CHANGELOG.md
+++ b/packages/apptive_grid_form/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 2.2.1
+
+ - **CHORE**: Bump hand_signature to ^3.1.0 (#146).
+
 ## 2.2.0
 
  - **FEAT**: Upgrade to Flutter 3.44.0 compatible dependencies (flutter_typeahead ^6.0.0, file_picker ^11.0.0, permission_handler ^12.0.0).

--- a/packages/apptive_grid_form/pubspec.yaml
+++ b/packages/apptive_grid_form/pubspec.yaml
@@ -1,6 +1,6 @@
 name: apptive_grid_form
 description: A Flutter Package to display ApptiveGrid Forms inside a Flutter App.
-version: 2.2.0
+version: 2.2.1
 homepage: https://www.apptivegrid.de
 repository: https://github.com/ApptiveGrid/apptive_grid_flutter/tree/main/packages/apptive_grid_form
 


### PR DESCRIPTION
## Release

Bumps the two packages that had unreleased changes on \`main\` (pub.dev is otherwise in sync).

| Package | Bump | Change |
|---------|------|--------|
| \`apptive_grid_core\` | 2.1.7 → **2.1.8** | **FIX**: Only listen for auth redirect when a redirect scheme is set (#147) |
| \`apptive_grid_form\` | 2.2.0 → **2.2.1** | **CHORE**: Bump hand_signature to ^3.1.0 (#146) |

No dependency constraints needed updating (\`apptive_grid_form\` already references \`apptive_grid_core: ^2.1.1\`, which covers 2.1.8).

### Verification
- \`melos bootstrap\` ✓
- \`dart analyze --fatal-infos\` — no issues (both packages)
- \`flutter test\` — core 626 ✓, form 259 ✓
- \`flutter pub publish --dry-run\` — clean (only the expected git-state warning + melos pubspec_overrides hint)

After merge, publish via \`melos publish\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)